### PR TITLE
`update_settings` doesn't allow attached deposit

### DIFF
--- a/contracts/cw-croncat/src/error.rs
+++ b/contracts/cw-croncat/src/error.rs
@@ -30,6 +30,9 @@ pub enum ContractError {
     #[error("Not a registered agent")]
     AgentUnregistered {},
 
+    #[error("Can't attach deposit")]
+    AttachedDeposit {},
+
     #[error("Custom Error val: {val:?}")]
     CustomError { val: String },
     // Add any other custom errors you like here.

--- a/contracts/cw-croncat/src/owner.rs
+++ b/contracts/cw-croncat/src/owner.rs
@@ -290,6 +290,14 @@ mod tests {
             _ => panic!("Must return unauthorized error"),
         }
 
+        // non-zero deposit fails
+        let with_deposit_info = mock_info("owner_id", &coins(1000, "meow"));
+        let res_fail = store.execute(deps.as_mut(), mock_env(), with_deposit_info, payload.clone());
+        match res_fail {
+            Err(ContractError::AttachedDeposit {}) => {}
+            _ => panic!("Must return deposit error"),
+        }
+
         // do the right thing
         let res_exec = store
             .execute(deps.as_mut(), mock_env(), info.clone(), payload)

--- a/contracts/cw-croncat/src/owner.rs
+++ b/contracts/cw-croncat/src/owner.rs
@@ -45,7 +45,9 @@ impl<'a> CwCroncat<'a> {
         info: MessageInfo,
         payload: ExecuteMsg,
     ) -> Result<Response, ContractError> {
-        // TODO: Panic on attach funds
+        if !info.funds.is_empty() {
+            return Err(ContractError::AttachedDeposit {});
+        }
         match payload {
             ExecuteMsg::UpdateSettings {
                 owner_id,

--- a/contracts/cw-croncat/src/owner.rs
+++ b/contracts/cw-croncat/src/owner.rs
@@ -242,7 +242,7 @@ mod tests {
     use crate::error::ContractError;
     use crate::state::CwCroncat;
     use cosmwasm_std::testing::{mock_dependencies_with_balance, mock_env, mock_info};
-    use cosmwasm_std::{coin, coins, from_binary, Addr};
+    use cosmwasm_std::{coin, coins, from_binary, Addr, MessageInfo};
     use cw20::Balance;
     use cw_croncat_core::msg::{
         BalancesResponse, ConfigResponse, ExecuteMsg, InstantiateMsg, QueryMsg,
@@ -258,7 +258,10 @@ mod tests {
             owner_id: None,
             agent_nomination_duration: Some(360),
         };
-        let info = mock_info("creator", &coins(1000, "meow"));
+        let info = MessageInfo {
+            sender: Addr::unchecked("creator"),
+            funds: vec![],
+        };
         let res_init = store
             .instantiate(deps.as_mut(), mock_env(), info.clone(), msg)
             .unwrap();
@@ -277,7 +280,10 @@ mod tests {
         };
 
         // non-owner fails
-        let unauth_info = mock_info("michael_scott", &coins(2, "shrute_bucks"));
+        let unauth_info = MessageInfo {
+            sender: Addr::unchecked("michael_scott"),
+            funds: vec![],
+        };
         let res_fail = store.execute(deps.as_mut(), mock_env(), unauth_info, payload.clone());
         match res_fail {
             Err(ContractError::Unauthorized {}) => {}
@@ -330,8 +336,12 @@ mod tests {
             proxy_callback_gas: None,
             slot_granularity: None,
         };
+        let info_setting = MessageInfo {
+            sender: Addr::unchecked("owner_id"),
+            funds: vec![],
+        };
         let res_exec = store
-            .execute(deps.as_mut(), mock_env(), info.clone(), payload)
+            .execute(deps.as_mut(), mock_env(), info_setting, payload)
             .unwrap();
         assert!(res_exec.messages.is_empty());
 
@@ -389,8 +399,12 @@ mod tests {
             proxy_callback_gas: None,
             slot_granularity: None,
         };
+        let info_settings = MessageInfo {
+            sender: Addr::unchecked("owner_id"),
+            funds: vec![],
+        };
         let res_exec = store
-            .execute(deps.as_mut(), mock_env(), info.clone(), payload)
+            .execute(deps.as_mut(), mock_env(), info_settings, payload)
             .unwrap();
         assert!(res_exec.messages.is_empty());
 


### PR DESCRIPTION
Closes #23

`update_settings` doesn't allow attached funds (but allows attaching coins with zero amount).
Changed tests `update_settings`, `move_balances_auth_checks` and `move_balances_native` so that they don't attach deposit to `execute` with `ExecuteMsg::UpdateSettings`. 