### PR TITLE
Preliminary work on getting the tasks for an agent

### DIFF
--- a/contracts/cw-croncat/src/agent.rs
+++ b/contracts/cw-croncat/src/agent.rs
@@ -9,7 +9,7 @@ use cw20::Balance;
 use std::ops::Div;
 
 use crate::ContractError::AgentNotRegistered;
-use cw_croncat_core::msg::{GetAgentIdsResponse, GetAgentTasksResponse};
+use cw_croncat_core::msg::{GetAgentIdsResponse, AgentTaskResponse};
 use cw_croncat_core::types::{Agent, AgentResponse, AgentStatus};
 
 impl<'a> CwCroncat<'a> {
@@ -78,7 +78,7 @@ impl<'a> CwCroncat<'a> {
         deps: Deps,
         env: Env,
         account_id: Addr,
-    ) -> StdResult<Option<GetAgentTasksResponse>> {
+    ) -> StdResult<Option<AgentTaskResponse>> {
         let active = self.agent_active_queue.load(deps.storage)?;
         if !active.contains(&account_id) {
             // TODO: unsure if we can return AgentNotRegistered
@@ -130,7 +130,7 @@ impl<'a> CwCroncat<'a> {
             num_cron_tasks = task_total_each_agent.into();
         }
 
-        Ok(Some(GetAgentTasksResponse {
+        Ok(Some(AgentTaskResponse {
             num_block_tasks,
             num_cron_tasks,
         }))
@@ -1316,7 +1316,7 @@ mod tests {
         let mut msg_agent_tasks = QueryMsg::GetAgentTasks {
             account_id: Addr::unchecked(AGENT1),
         };
-        let mut query_task_res: StdResult<Option<GetAgentTasksResponse>> = app
+        let mut query_task_res: StdResult<Option<AgentTaskResponse>> = app
             .wrap()
             .query_wasm_smart(contract_addr.clone(), &msg_agent_tasks);
         println!(

--- a/contracts/cw-croncat/src/agent.rs
+++ b/contracts/cw-croncat/src/agent.rs
@@ -3,11 +3,12 @@ use crate::helpers::{send_tokens, GenericBalance};
 use crate::state::{Config, CwCroncat};
 use cosmwasm_std::{
     has_coins, Addr, Coin, Deps, DepsMut, Env, MessageInfo, Response, StdError, StdResult, Storage,
-    SubMsg,
+    SubMsg, Uint64,
 };
 use cw20::Balance;
 use std::ops::Div;
 
+use crate::ContractError::AgentNotRegistered;
 use cw_croncat_core::msg::{GetAgentIdsResponse, GetAgentTasksResponse};
 use cw_croncat_core::types::{Agent, AgentResponse, AgentStatus};
 
@@ -77,19 +78,62 @@ impl<'a> CwCroncat<'a> {
         deps: Deps,
         env: Env,
         account_id: Addr,
-    ) -> StdResult<GetAgentTasksResponse> {
-        let empty = GetAgentTasksResponse(0, 0);
+    ) -> StdResult<Option<GetAgentTasksResponse>> {
         let active = self.agent_active_queue.load(deps.storage)?;
-        let slot = self.get_current_slot_items(&env.block, deps.storage);
-
-        if active.contains(&account_id) {
-            if let Some(slot) = slot {
-                return Ok(GetAgentTasksResponse(1, slot.0));
-            }
-            return Ok(GetAgentTasksResponse(1, 0));
+        if !active.contains(&account_id) {
+            // TODO: unsure if we can return AgentNotRegistered
+            return Err(StdError::GenericErr {
+                msg: AgentNotRegistered {}.to_string(),
+            });
         }
 
-        Ok(empty)
+        // Get all tasks (the final None means no limit when we take)
+        let slot_items = self.get_current_slot_items(&env.block, deps.storage, None);
+
+        if slot_items == (None, None) {
+            return Ok(None);
+        }
+        let mut num_block_tasks = Uint64::from(0u64);
+        let mut num_cron_tasks = Uint64::from(0u64);
+        // This below line is commented out and will be used with
+        // the rotating index (see Config's agent_active_indices)
+        // let agent_active_queue_indices: Vec<usize> = (0..active.len()).collect();
+        if let Some(current_block_task_total) = slot_items.0 {
+            // Integer division to determine how much each gets
+            let task_total_each_agent = current_block_task_total / active.len() as u64;
+
+            // Divvy up the modulo leftovers using the active index
+            // TODO: we must give the leftover tasks to some agents.
+            // Still need to implement the "round table" idea, where we use Config's agent_active_indices
+            // let agent_active_index = agent_active_queue
+            //     .iter()
+            //     .position(|x| x == &account_id)
+            //     .expect("Agent not active");
+            // let leftover_tasks = total_tasks % agent_active_queue.len() as u64;
+
+            num_block_tasks = task_total_each_agent.into();
+        }
+        // Do time slots
+        if let Some(current_cron_task_total) = slot_items.1 {
+            // Integer division to determine how much each gets
+            let task_total_each_agent = current_cron_task_total / active.len() as u64;
+
+            // Divvy up the modulo leftovers using the active index
+            // TODO: we must give the leftover tasks to some agents.
+            // Still need to implement the "round table" idea, where we use Config's agent_active_indices
+            // let agent_active_index = agent_active_queue
+            //     .iter()
+            //     .position(|x| x == &account_id)
+            //     .expect("Agent not active");
+            // let leftover_tasks = total_tasks % agent_active_queue.len() as u64;
+
+            num_cron_tasks = task_total_each_agent.into();
+        }
+
+        Ok(Some(GetAgentTasksResponse {
+            num_block_tasks,
+            num_cron_tasks,
+        }))
     }
 
     /// Add any account as an agent that will be able to execute tasks.
@@ -470,6 +514,74 @@ mod tests {
             &ExecuteMsg::CreateTask {
                 task: TaskRequest {
                     interval: Interval::Immediate,
+                    boundary: Boundary {
+                        start: None,
+                        end: None,
+                    },
+                    stop_on_fail: false,
+                    actions: vec![Action {
+                        msg,
+                        gas_limit: Some(150_000),
+                    }],
+                    rules: None,
+                },
+            },
+            send_funds.as_ref(),
+        )
+        .expect("Error adding task")
+    }
+
+    fn add_block_task_exec(
+        app: &mut App,
+        contract_addr: &Addr,
+        sender: &str,
+        block_num: u64,
+    ) -> AppResponse {
+        let validator = String::from("you");
+        let amount = coin(3, NATIVE_DENOM);
+        let stake = StakingMsg::Delegate { validator, amount };
+        let msg: CosmosMsg = stake.clone().into();
+        let send_funds = coins(1, NATIVE_DENOM);
+        app.execute_contract(
+            Addr::unchecked(sender),
+            contract_addr.clone(),
+            &ExecuteMsg::CreateTask {
+                task: TaskRequest {
+                    interval: Interval::Block(block_num),
+                    boundary: Boundary {
+                        start: None,
+                        end: None,
+                    },
+                    stop_on_fail: false,
+                    actions: vec![Action {
+                        msg,
+                        gas_limit: Some(150_000),
+                    }],
+                    rules: None,
+                },
+            },
+            send_funds.as_ref(),
+        )
+        .expect("Error adding task")
+    }
+
+    fn add_cron_task_exec(
+        app: &mut App,
+        contract_addr: &Addr,
+        sender: &str,
+        num_minutes: u64,
+    ) -> AppResponse {
+        let validator = String::from("you");
+        let amount = coin(3, NATIVE_DENOM);
+        let stake = StakingMsg::Delegate { validator, amount };
+        let msg: CosmosMsg = stake.clone().into();
+        let send_funds = coins(1, NATIVE_DENOM);
+        app.execute_contract(
+            Addr::unchecked(sender),
+            contract_addr.clone(),
+            &ExecuteMsg::CreateTask {
+                task: TaskRequest {
+                    interval: Interval::Cron(format!("* {} * * * *", num_minutes)),
                     boundary: Boundary {
                         start: None,
                         end: None,
@@ -1130,5 +1242,106 @@ mod tests {
             agent_status_res.unwrap(),
             "New agent should have nominated status"
         );
+    }
+
+    #[test]
+    fn test_query_get_agent_tasks() {
+        let (mut app, cw_template_contract) = proper_instantiate();
+        let contract_addr = cw_template_contract.addr();
+        let block_info = app.block_info();
+        println!(
+            "test aloha\n\tcurrent block: {}\n\tcurrent time: {}",
+            block_info.height,
+            block_info.time.nanos()
+        );
+
+        // Register AGENT1, who immediately becomes active
+        register_agent_exec(&mut app, &contract_addr, AGENT1, &AGENT_BENEFICIARY);
+        // Add five tasks total
+        // Three of them are block-based
+        add_block_task_exec(
+            &mut app,
+            &contract_addr,
+            PARTICIPANT0,
+            block_info.height + 6,
+        );
+        add_block_task_exec(
+            &mut app,
+            &contract_addr,
+            PARTICIPANT1,
+            block_info.height + 66,
+        );
+        add_block_task_exec(
+            &mut app,
+            &contract_addr,
+            PARTICIPANT2,
+            block_info.height + 67,
+        );
+        // add_block_task_exec(&mut app, &contract_addr, PARTICIPANT3, block_info.height + 131);
+        // Two tasks use Cron instead of Block (for task interval)
+        add_cron_task_exec(&mut app, &contract_addr, PARTICIPANT4, 6); // 3 minutes
+        add_cron_task_exec(&mut app, &contract_addr, PARTICIPANT5, 53); // 53 minutes
+        let num_tasks = get_task_total(&app, &contract_addr);
+        assert_eq!(num_tasks, 5);
+
+        // Now the task ratio is 1:2 (one agent per two tasks)
+        // Register two agents, the first one succeeding
+        register_agent_exec(&mut app, &contract_addr, AGENT2, &AGENT_BENEFICIARY);
+        assert!(check_in_exec(&mut app, &contract_addr, AGENT2).is_ok());
+        // This next agent should fail because there's no enough tasks yet
+        // Later, we'll have this agent try to nominate themselves before their time
+        register_agent_exec(&mut app, &contract_addr, AGENT3, &AGENT_BENEFICIARY);
+        let failed_check_in = check_in_exec(&mut app, &contract_addr, AGENT3);
+        assert_eq!(
+            ContractError::CustomError {
+                val: "Not accepting new agents".to_string()
+            },
+            failed_check_in.unwrap_err().downcast().unwrap()
+        );
+
+        let (_, num_active_agents, num_pending_agents) = get_agent_ids(&app, &contract_addr);
+        assert_eq!(2, num_active_agents);
+        assert_eq!(1, num_pending_agents);
+
+        // Fast forward time a little
+        app.update_block(|block| {
+            let height = 666;
+            block.time = block.time.plus_seconds(6 * height); // ~6 sec block time
+            block.height = block.height + height;
+        });
+
+        // What happens when the only active agent queries to see if there's work for them
+        // calls:
+        // fn query_get_agent_tasks
+        let mut msg_agent_tasks = QueryMsg::GetAgentTasks {
+            account_id: Addr::unchecked(AGENT1),
+        };
+        let mut query_task_res: StdResult<Option<GetAgentTasksResponse>> = app
+            .wrap()
+            .query_wasm_smart(contract_addr.clone(), &msg_agent_tasks);
+        println!(
+            "test aloha query_task_res0 {:#?}",
+            query_task_res.as_ref().unwrap()
+        );
+        assert!(
+            query_task_res.is_ok(),
+            "Did not successfully find the newly added task"
+        );
+        msg_agent_tasks = QueryMsg::GetAgentTasks {
+            account_id: Addr::unchecked(AGENT2),
+        };
+        query_task_res = app
+            .wrap()
+            .query_wasm_smart(contract_addr.clone(), &msg_agent_tasks);
+        println!("test aloha query_task_res1 {:#?}", query_task_res.unwrap());
+        // Should fail for random user not in the active queue
+        msg_agent_tasks = QueryMsg::GetAgentTasks {
+            // rando account
+            account_id: Addr::unchecked("juno1kqfjv53g7ll9u6ngvsu5l5nfv9ht24m4q4gdqz"),
+        };
+        query_task_res = app
+            .wrap()
+            .query_wasm_smart(contract_addr.clone(), &msg_agent_tasks);
+        println!("aloha query_task_res {:?}", query_task_res);
     }
 }

--- a/contracts/cw-croncat/src/agent.rs
+++ b/contracts/cw-croncat/src/agent.rs
@@ -95,6 +95,8 @@ impl<'a> CwCroncat<'a> {
         }
         let mut num_block_tasks = Uint64::from(0u64);
         let mut num_cron_tasks = Uint64::from(0u64);
+        let num_block_tasks_extra = Uint64::from(0u64);
+        let num_cron_tasks_extra = Uint64::from(0u64);
         // This below line is commented out and will be used with
         // the rotating index (see Config's agent_active_indices)
         // let agent_active_queue_indices: Vec<usize> = (0..active.len()).collect();
@@ -132,6 +134,8 @@ impl<'a> CwCroncat<'a> {
 
         Ok(Some(AgentTaskResponse {
             num_block_tasks,
+            num_block_tasks_extra,
+            num_cron_tasks_extra,
             num_cron_tasks,
         }))
     }

--- a/contracts/cw-croncat/src/agent.rs
+++ b/contracts/cw-croncat/src/agent.rs
@@ -9,7 +9,7 @@ use cw20::Balance;
 use std::ops::Div;
 
 use crate::ContractError::AgentNotRegistered;
-use cw_croncat_core::msg::{GetAgentIdsResponse, AgentTaskResponse};
+use cw_croncat_core::msg::{AgentTaskResponse, GetAgentIdsResponse};
 use cw_croncat_core::types::{Agent, AgentResponse, AgentStatus};
 
 impl<'a> CwCroncat<'a> {

--- a/contracts/cw-croncat/src/balancer.rs
+++ b/contracts/cw-croncat/src/balancer.rs
@@ -8,8 +8,13 @@ use cw_croncat_core::types::{Agent, SlotType, Task};
 use cw_storage_plus::IndexedMap;
 use cw_storage_plus::Item;
 
+#[derive(PartialEq)]
+pub enum BalancerMode {
+    ActivationOrder,
+    Equalizer,
+}
 pub trait Balancer<'a> {
-    fn next_task(
+    fn get_agent_tasks(
         &mut self,
         deps: Deps,
         env: Env,
@@ -20,15 +25,37 @@ pub trait Balancer<'a> {
     ) -> StdResult<Option<AgentTaskResponse>>;
 }
 
-pub struct RoundRobinBalancer {}
+pub struct RoundRobinBalancer {
+    pub mode: BalancerMode,
+}
 
 impl<'a> RoundRobinBalancer {
-    pub fn new() -> RoundRobinBalancer {
-        return RoundRobinBalancer {};
+    pub fn default() -> RoundRobinBalancer {
+        return RoundRobinBalancer::new(BalancerMode::ActivationOrder);
+    }
+    pub fn new(mode: BalancerMode) -> RoundRobinBalancer {
+        return RoundRobinBalancer { mode };
+    }
+    fn update_or_append(
+        &self,
+        overflows: &mut Vec<(SlotType, u32, u32)>,
+        value: (SlotType, u32, u32),
+    ) {
+        match overflows
+            .iter_mut()
+            .find(|ref p| p.0 == value.0 && p.1 == value.1)
+        {
+            Some(found) => {
+                found.2 += value.2;
+            }
+            None => {
+                overflows.push(value);
+            }
+        }
     }
 }
 impl<'a> Balancer<'a> for RoundRobinBalancer {
-    fn next_task(
+    fn get_agent_tasks(
         &mut self,
         deps: Deps,
         env: Env,
@@ -37,16 +64,14 @@ impl<'a> Balancer<'a> for RoundRobinBalancer {
         agent_id: Addr,
         slot_items: (Option<u64>, Option<u64>),
     ) -> StdResult<Option<AgentTaskResponse>> {
-
         let conf: Config = config.load(deps.storage)?;
         let active = active_agents.load(deps.storage)?;
         if !active.contains(&agent_id) {
-            // TODO: unsure if we can return AgentNotRegistered
             return Err(StdError::GenericErr {
                 msg: AgentNotRegistered {}.to_string(),
             });
         }
-        let agent_active_indices_config=conf.agent_active_indices;
+        let agent_active_indices_config = conf.agent_active_indices;
         let agent_active_indices: Vec<usize> = (0..active.len()).collect();
         let agent_index = active
             .iter()
@@ -59,9 +84,25 @@ impl<'a> Balancer<'a> for RoundRobinBalancer {
         let mut num_block_tasks = Uint64::from(0u64);
         let mut num_cron_tasks = Uint64::from(0u64);
 
-        Ok(Some(AgentTaskResponse {
-            num_block_tasks,
-            num_cron_tasks,
-        }))
+        match self.mode {
+            BalancerMode::ActivationOrder => {
+                if let Some(current_block_task_total) = slot_items.0 {
+                    if current_block_task_total <= active.len() as u64 {
+                        num_block_tasks = (current_block_task_total - agent_index as u64).into();
+                    } else {
+                        let leftover = current_block_task_total % active.len() as u64;
+                    }
+                }
+                if let Some(current_cron_task_total) = slot_items.1 {
+                    if current_cron_task_total <= active.len() as u64 {}
+                }
+
+                Ok(Some(AgentTaskResponse {
+                    num_block_tasks,
+                    num_cron_tasks,
+                }))
+            }
+            BalancerMode::Equalizer => todo!(),
+        }
     }
 }

--- a/contracts/cw-croncat/src/balancer.rs
+++ b/contracts/cw-croncat/src/balancer.rs
@@ -101,15 +101,14 @@ impl<'a> Balancer<'a> for RoundRobinBalancer {
                     } else {
                         let leftover = total_tasks % agent_count;
 
-                        let mut rich_agents: Vec<(SlotType, u32, u32)> = vec![];
+                        let mut rich_agents: Vec<(SlotType, u32, u32)> =
+                            agent_active_indices_config
+                                .clone()
+                                .into_iter()
+                                .filter(|e| e.2 > 0)
+                                .collect::<_>();
 
-                        if let Some(entry) = agent_active_indices_config.first() {
-                            if entry.1 > 0 || entry.2 > 0 {
-                                //Not empty value
-                                rich_agents = agent_active_indices_config.clone();
-                                rich_agents.sort_by(|a, b| a.2.partial_cmp(&b.2).unwrap());
-                            }
-                        }
+                        rich_agents.sort_by(|a, b| a.2.partial_cmp(&b.2).unwrap());
                         let rich_indices: Vec<usize> =
                             rich_agents.iter().map(|v| v.1 as usize).collect();
 

--- a/contracts/cw-croncat/src/balancer.rs
+++ b/contracts/cw-croncat/src/balancer.rs
@@ -1,0 +1,67 @@
+use crate::state::Config;
+use crate::state::TaskIndexes;
+use crate::{slots, ContractError::AgentNotRegistered};
+use cosmwasm_std::Uint64;
+use cosmwasm_std::{Addr, Deps, Env, StdError, StdResult, Storage};
+use cw_croncat_core::msg::AgentTaskResponse;
+use cw_croncat_core::types::{Agent, SlotType, Task};
+use cw_storage_plus::IndexedMap;
+use cw_storage_plus::Item;
+
+pub trait Balancer<'a> {
+    fn next_task(
+        &mut self,
+        deps: Deps,
+        env: Env,
+        config: &Item<'a, Config>,
+        active_agents: &Item<'a, Vec<Addr>>,
+        agent_id: Addr,
+        slot_items: (Option<u64>, Option<u64>),
+    ) -> StdResult<Option<AgentTaskResponse>>;
+}
+
+pub struct RoundRobinBalancer {}
+
+impl<'a> RoundRobinBalancer {
+    pub fn new() -> RoundRobinBalancer {
+        return RoundRobinBalancer {};
+    }
+}
+impl<'a> Balancer<'a> for RoundRobinBalancer {
+    fn next_task(
+        &mut self,
+        deps: Deps,
+        env: Env,
+        config: &Item<'a, Config>,
+        active_agents: &Item<'a, Vec<Addr>>,
+        agent_id: Addr,
+        slot_items: (Option<u64>, Option<u64>),
+    ) -> StdResult<Option<AgentTaskResponse>> {
+
+        let conf: Config = config.load(deps.storage)?;
+        let active = active_agents.load(deps.storage)?;
+        if !active.contains(&agent_id) {
+            // TODO: unsure if we can return AgentNotRegistered
+            return Err(StdError::GenericErr {
+                msg: AgentNotRegistered {}.to_string(),
+            });
+        }
+        let agent_active_indices_config=conf.agent_active_indices;
+        let agent_active_indices: Vec<usize> = (0..active.len()).collect();
+        let agent_index = active
+            .iter()
+            .position(|x| x == &agent_id)
+            .expect("Agent not active or not registered!");
+
+        if slot_items == (None, None) {
+            return Ok(None);
+        }
+        let mut num_block_tasks = Uint64::from(0u64);
+        let mut num_cron_tasks = Uint64::from(0u64);
+
+        Ok(Some(AgentTaskResponse {
+            num_block_tasks,
+            num_cron_tasks,
+        }))
+    }
+}

--- a/contracts/cw-croncat/src/balancer.rs
+++ b/contracts/cw-croncat/src/balancer.rs
@@ -105,7 +105,7 @@ impl<'a> Balancer<'a> for RoundRobinBalancer {
                             rich_agents.iter().map(|v| v.1 as usize).collect();
 
                         let mut diff = vect_difference(&agent_active_indices, &rich_indices);
-                        diff.extend(rich_indices.clone());
+                        diff.extend(rich_indices);
                         let agent_index = diff
                             .iter()
                             .position(|x| x == &(agent_index as usize))
@@ -114,7 +114,7 @@ impl<'a> Balancer<'a> for RoundRobinBalancer {
 
                         let extra = 1u64
                             .saturating_sub(agent_index.saturating_sub(leftover.saturating_sub(1)));
-                        
+
                         // println!("rich_indices-{:?}", rich_indices);
 
                         // println!("leftover-{}", leftover);

--- a/contracts/cw-croncat/src/balancer.rs
+++ b/contracts/cw-croncat/src/balancer.rs
@@ -104,7 +104,8 @@ impl<'a> Balancer<'a> for RoundRobinBalancer {
                         let mut rich_agents: Vec<(SlotType, u32, u32)> = vec![];
 
                         if let Some(entry) = agent_active_indices_config.first() {
-                            if entry.1>0 || entry.1>0 || entry.2 > 0 { //Not empty value
+                            if entry.1 > 0 || entry.2 > 0 {
+                                //Not empty value
                                 rich_agents = agent_active_indices_config.clone();
                                 rich_agents.sort_by(|a, b| a.2.partial_cmp(&b.2).unwrap());
                             }

--- a/contracts/cw-croncat/src/contract.rs
+++ b/contracts/cw-croncat/src/contract.rs
@@ -42,7 +42,7 @@ impl<'a> CwCroncat<'a> {
             owner_id: owner_acct,
             // treasury_id: None,
             min_tasks_per_agent: 3,
-            agent_active_indices: vec![(SlotType::Block, 0), (SlotType::Cron, 0)],
+            agent_active_indices: vec![(SlotType::Block, 0,0), (SlotType::Cron, 0,0)],
             agents_eject_threshold: 600, // how many slots an agent can miss before being ejected. 10 * 60 = 1hr
             available_balance,
             staked_balance: GenericBalance::default(),
@@ -221,7 +221,7 @@ mod tests {
         // assert_eq!(None, value.treasury_id);
         assert_eq!(3, value.min_tasks_per_agent);
         assert_eq!(
-            vec![(SlotType::Block, 0), (SlotType::Cron, 0)],
+            vec![(SlotType::Block, 0,0), (SlotType::Cron, 0,0)],
             value.agent_active_indices
         );
         assert_eq!(600, value.agents_eject_threshold);

--- a/contracts/cw-croncat/src/contract.rs
+++ b/contracts/cw-croncat/src/contract.rs
@@ -8,7 +8,6 @@ use cosmwasm_std::{
 use cw2::set_contract_version;
 use cw20::Balance;
 use cw_croncat_core::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
-use cw_croncat_core::types::SlotType;
 
 // version info for migration info
 const CONTRACT_NAME: &str = "crates.io:cw-croncat";

--- a/contracts/cw-croncat/src/contract.rs
+++ b/contracts/cw-croncat/src/contract.rs
@@ -8,6 +8,7 @@ use cosmwasm_std::{
 use cw2::set_contract_version;
 use cw20::Balance;
 use cw_croncat_core::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
+use cw_croncat_core::types::SlotType;
 
 // version info for migration info
 const CONTRACT_NAME: &str = "crates.io:cw-croncat";
@@ -41,7 +42,7 @@ impl<'a> CwCroncat<'a> {
             owner_id: owner_acct,
             // treasury_id: None,
             min_tasks_per_agent: 3,
-            agent_active_indices: vec![],
+            agent_active_indices: vec![(SlotType::Block, 0, 0), (SlotType::Cron, 0, 0)],
             agents_eject_threshold: 600, // how many slots an agent can miss before being ejected. 10 * 60 = 1hr
             available_balance,
             staked_balance: GenericBalance::default(),
@@ -191,6 +192,7 @@ mod tests {
         coin, coins, from_binary, Addr, Binary, Event, Reply, SubMsgResponse, SubMsgResult,
     };
     use cw_croncat_core::msg::{ConfigResponse, QueryMsg};
+    use cw_croncat_core::types::SlotType;
 
     #[test]
     fn configure() {

--- a/contracts/cw-croncat/src/contract.rs
+++ b/contracts/cw-croncat/src/contract.rs
@@ -42,7 +42,7 @@ impl<'a> CwCroncat<'a> {
             owner_id: owner_acct,
             // treasury_id: None,
             min_tasks_per_agent: 3,
-            agent_active_indices: vec![(SlotType::Block, 0, 0), (SlotType::Cron, 0, 0)],
+            agent_active_indices: vec![],
             agents_eject_threshold: 600, // how many slots an agent can miss before being ejected. 10 * 60 = 1hr
             available_balance,
             staked_balance: GenericBalance::default(),

--- a/contracts/cw-croncat/src/contract.rs
+++ b/contracts/cw-croncat/src/contract.rs
@@ -42,7 +42,7 @@ impl<'a> CwCroncat<'a> {
             owner_id: owner_acct,
             // treasury_id: None,
             min_tasks_per_agent: 3,
-            agent_active_indices: vec![(SlotType::Block, 0,0), (SlotType::Cron, 0,0)],
+            agent_active_indices: vec![(SlotType::Block, 0, 0), (SlotType::Cron, 0, 0)],
             agents_eject_threshold: 600, // how many slots an agent can miss before being ejected. 10 * 60 = 1hr
             available_balance,
             staked_balance: GenericBalance::default(),
@@ -221,7 +221,7 @@ mod tests {
         // assert_eq!(None, value.treasury_id);
         assert_eq!(3, value.min_tasks_per_agent);
         assert_eq!(
-            vec![(SlotType::Block, 0,0), (SlotType::Cron, 0,0)],
+            vec![(SlotType::Block, 0, 0), (SlotType::Cron, 0, 0)],
             value.agent_active_indices
         );
         assert_eq!(600, value.agents_eject_threshold);

--- a/contracts/cw-croncat/src/helpers.rs
+++ b/contracts/cw-croncat/src/helpers.rs
@@ -11,6 +11,12 @@ use serde::{Deserialize, Serialize};
 use std::cmp;
 use std::ops::Div;
 
+pub(crate) fn vect_difference<T: std::clone::Clone + std::cmp::PartialEq>(
+    v1: &Vec<T>,
+    v2: &Vec<T>,
+) -> Vec<T> {
+    v1.iter().filter(|&x| !v2.contains(x)).cloned().collect()
+}
 // Helper to distribute funds/tokens
 pub(crate) fn send_tokens(
     to: &Addr,

--- a/contracts/cw-croncat/src/helpers.rs
+++ b/contracts/cw-croncat/src/helpers.rs
@@ -12,8 +12,8 @@ use std::cmp;
 use std::ops::Div;
 
 pub(crate) fn vect_difference<T: std::clone::Clone + std::cmp::PartialEq>(
-    v1: &Vec<T>,
-    v2: &Vec<T>,
+    v1: &[T],
+    v2: &[T],
 ) -> Vec<T> {
     v1.iter().filter(|&x| !v2.contains(x)).cloned().collect()
 }

--- a/contracts/cw-croncat/src/lib.rs
+++ b/contracts/cw-croncat/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod agent;
+pub mod balancer;
 pub mod contract;
 mod error;
 pub mod helpers;
@@ -8,7 +9,6 @@ pub mod slots;
 pub mod state;
 pub mod tasks;
 pub mod traits;
-pub mod balancer;
 pub use crate::error::ContractError;
 pub use crate::state::CwCroncat;
 use cosmwasm_std::entry_point;

--- a/contracts/cw-croncat/src/lib.rs
+++ b/contracts/cw-croncat/src/lib.rs
@@ -8,7 +8,7 @@ pub mod slots;
 pub mod state;
 pub mod tasks;
 pub mod traits;
-
+pub mod balancer;
 pub use crate::error::ContractError;
 pub use crate::state::CwCroncat;
 use cosmwasm_std::entry_point;

--- a/contracts/cw-croncat/src/owner.rs
+++ b/contracts/cw-croncat/src/owner.rs
@@ -16,7 +16,7 @@ impl<'a> CwCroncat<'a> {
             owner_id: c.owner_id,
             // treasury_id: c.treasury_id,
             min_tasks_per_agent: c.min_tasks_per_agent,
-            agent_active_index: c.agent_active_index,
+            agent_active_indices: c.agent_active_indices,
             agents_eject_threshold: c.agents_eject_threshold,
             native_denom: c.native_denom,
             agent_fee: c.agent_fee,
@@ -113,7 +113,13 @@ impl<'a> CwCroncat<'a> {
             //         .to_string(),
             // )
             .add_attribute("min_tasks_per_agent", c.min_tasks_per_agent.to_string())
-            .add_attribute("agent_active_index", c.agent_active_index.to_string())
+            .add_attribute(
+                "agent_active_indices",
+                c.agent_active_indices
+                    .iter()
+                    .map(|a| format!("{:?}.{}", a.0, a.1))
+                    .collect::<String>(),
+            )
             .add_attribute(
                 "agents_eject_threshold",
                 c.agents_eject_threshold.to_string(),

--- a/contracts/cw-croncat/src/slots.rs
+++ b/contracts/cw-croncat/src/slots.rs
@@ -157,40 +157,53 @@ impl IntervalExt for Interval {
 
 impl<'a> CwCroncat<'a> {
     /// Get the slot with lowest height/timestamp
-    /// Returns (block slot, time slot)
+    /// Returns a tuple of optionals: (Option<block height>, Option<timestamp>)
     /// NOTE: This prioritizes blocks over timestamps.
     pub(crate) fn get_current_slot_items(
         &self,
         block: &BlockInfo,
         storage: &dyn Storage,
-    ) -> Option<(u64, SlotType)> {
+        limit: Option<usize>,
+    ) -> (Option<u64>, Option<u64>) {
+        let mut ret: (Option<u64>, Option<u64>) = (None, None);
         let block_height = block.height;
-        let block_slot: StdResult<Vec<u64>> = self
-            .block_slots
-            .keys(storage, None, None, Order::Ascending)
-            .take(1)
-            .collect();
+
+        let block_slot: StdResult<Vec<u64>> = if let Some(l) = limit {
+            self.block_slots
+                .keys(storage, None, None, Order::Ascending)
+                .take(l)
+                .collect()
+        } else {
+            self.block_slots
+                .keys(storage, None, None, Order::Ascending)
+                .collect()
+        };
 
         if let Ok(Some(block_id)) = block_slot.map(|v| v.first().copied()) {
             if block_height >= block_id {
-                return Some((block_id, SlotType::Block));
+                ret.0 = Some(block_id);
             }
         }
 
         let timestamp: u64 = block.time.nanos();
-        let time_slot: StdResult<Vec<u64>> = self
-            .time_slots
-            .keys(storage, None, None, Order::Ascending)
-            .take(1)
-            .collect();
+        let time_slot: StdResult<Vec<u64>> = if let Some(l) = limit {
+            self.time_slots
+                .keys(storage, None, None, Order::Ascending)
+                .take(l)
+                .collect()
+        } else {
+            self.time_slots
+                .keys(storage, None, None, Order::Ascending)
+                .collect()
+        };
 
         if let Ok(Some(time_id)) = time_slot.map(|v| v.first().copied()) {
             if timestamp >= time_id {
-                return Some((time_id, SlotType::Cron));
+                ret.1 = Some(time_id);
             }
         }
 
-        None
+        ret
     }
 
     /// Gets 1 slot hash item, and removes the hash from storage
@@ -312,31 +325,31 @@ mod tests {
             .to_vec();
 
         // Check for empty store
-        assert_eq!(None, store.get_current_slot_items(&mock_env.block, &deps.storage));
+        assert_eq!((None, None), store.get_current_slot_items(&mock_env.block, &deps.storage, None));
 
         // Setup of block and cron slots
         store.time_slots.save(&mut deps.storage, current_time + 1, &vec![task_hash.clone()]).unwrap();
         store.block_slots.save(&mut deps.storage, current_block + 1, &vec![task_hash.clone()]).unwrap();
 
         // Empty if not time/block yet
-        assert_eq!(None, store.get_current_slot_items(&mock_env.block, &deps.storage));
+        assert_eq!((None, None), store.get_current_slot_items(&mock_env.block, &deps.storage, None));
 
         // And returns task when it's time
         let mut mock_env = mock_env;
         mock_env.block.time = mock_env.block.time.plus_nanos(1);
-        assert_eq!(Some((current_time + 1, SlotType::Cron)),store.get_current_slot_items(&mock_env.block, &deps.storage));
+        assert_eq!((None, Some(current_time + 1)),store.get_current_slot_items(&mock_env.block, &deps.storage, None));
 
         // Or later
         mock_env.block.time = mock_env.block.time.plus_nanos(1);
-        assert_eq!(Some((current_time + 1, SlotType::Cron)),store.get_current_slot_items(&mock_env.block, &deps.storage));
+        assert_eq!((None, Some(current_time + 1)),store.get_current_slot_items(&mock_env.block, &deps.storage, None));
 
         // Check, that Block is preferred over cron and block height reached 
         mock_env.block.height += 1;
-        assert_eq!(Some((current_block + 1, SlotType::Block)),store.get_current_slot_items(&mock_env.block, &deps.storage));
+        assert_eq!((Some(current_block + 1), Some(current_time + 1)),store.get_current_slot_items(&mock_env.block, &deps.storage, None));
 
         // Or block(s) ahead
         mock_env.block.height += 1;
-        assert_eq!(Some((current_block + 1, SlotType::Block)),store.get_current_slot_items(&mock_env.block, &deps.storage));
+        assert_eq!((Some(current_block + 1), Some(current_time + 1)), store.get_current_slot_items(&mock_env.block, &deps.storage, None));
     }
 
     #[test]

--- a/contracts/cw-croncat/src/state.rs
+++ b/contracts/cw-croncat/src/state.rs
@@ -19,7 +19,7 @@ pub struct Config {
     // NOTE: Caveat, when there are odd number of tasks or agents, the overflow will be available to first-come, first-serve. This doesn't negate the possibility of a failed txn from race case choosing winner inside a block.
     // NOTE: The overflow will be adjusted to be handled by sweeper in next implementation.
     pub min_tasks_per_agent: u64,
-    pub agent_active_indices: Vec<(SlotType, u32)>,
+    pub agent_active_indices: Vec<(SlotType, u32,u32)>,
     // How many slots an agent can miss before being removed from the active queue
     pub agents_eject_threshold: u64,
     // This is a timestamp that's updated when a new task is added such that

--- a/contracts/cw-croncat/src/state.rs
+++ b/contracts/cw-croncat/src/state.rs
@@ -4,22 +4,23 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::helpers::Task;
-use cw_croncat_core::types::{Agent, GenericBalance};
+use cw_croncat_core::types::{Agent, GenericBalance, SlotType};
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct Config {
     // Runtime
     pub paused: bool,
     pub owner_id: Addr,
 
     // Agent management
-    // The maximum number of tasks per agent
+    // The minimum number of tasks per agent
     // Example: 10
     // Explanation: For every 1 agent, 10 tasks per slot are available.
-    // NOTE: Caveat, when there are odd number of tasks or agents, the overflow will be available to first-come first-serve. This doesn't negate the possibility of a failed txn from race case choosing winner inside a block.
+    // NOTE: Caveat, when there are odd number of tasks or agents, the overflow will be available to first-come, first-serve. This doesn't negate the possibility of a failed txn from race case choosing winner inside a block.
     // NOTE: The overflow will be adjusted to be handled by sweeper in next implementation.
     pub min_tasks_per_agent: u64,
-    pub agent_active_index: u64,
+    pub agent_active_indices: Vec<(SlotType, u32)>,
+    // How many slots an agent can miss before being removed from the active queue
     pub agents_eject_threshold: u64,
     // This is a timestamp that's updated when a new task is added such that
     // the agent/task ratio allows for another agent to join.

--- a/contracts/cw-croncat/src/state.rs
+++ b/contracts/cw-croncat/src/state.rs
@@ -19,7 +19,7 @@ pub struct Config {
     // NOTE: Caveat, when there are odd number of tasks or agents, the overflow will be available to first-come, first-serve. This doesn't negate the possibility of a failed txn from race case choosing winner inside a block.
     // NOTE: The overflow will be adjusted to be handled by sweeper in next implementation.
     pub min_tasks_per_agent: u64,
-    pub agent_active_indices: Vec<(SlotType, u32,u32)>,
+    pub agent_active_indices: Vec<(SlotType, u32, u32)>,
     // How many slots an agent can miss before being removed from the active queue
     pub agents_eject_threshold: u64,
     // This is a timestamp that's updated when a new task is added such that

--- a/packages/cw-croncat-core/src/msg.rs
+++ b/packages/cw-croncat-core/src/msg.rs
@@ -122,7 +122,7 @@ pub struct ConfigResponse {
     pub owner_id: Addr,
     // pub treasury_id: Option<Addr>,
     pub min_tasks_per_agent: u64,
-    pub agent_active_indices: Vec<(SlotType, u32)>,
+    pub agent_active_indices: Vec<(SlotType, u32,u32)>,
     pub agents_eject_threshold: u64,
     pub agent_fee: Coin,
     pub gas_price: u32,

--- a/packages/cw-croncat-core/src/msg.rs
+++ b/packages/cw-croncat-core/src/msg.rs
@@ -149,7 +149,9 @@ pub struct GetAgentIdsResponse {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct AgentTaskResponse {
     pub num_block_tasks: Uint64,
+    pub num_block_tasks_extra:Uint64,
     pub num_cron_tasks: Uint64,
+    pub num_cron_tasks_extra:Uint64,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/packages/cw-croncat-core/src/msg.rs
+++ b/packages/cw-croncat-core/src/msg.rs
@@ -122,7 +122,7 @@ pub struct ConfigResponse {
     pub owner_id: Addr,
     // pub treasury_id: Option<Addr>,
     pub min_tasks_per_agent: u64,
-    pub agent_active_indices: Vec<(SlotType, u32,u32)>,
+    pub agent_active_indices: Vec<(SlotType, u32, u32)>,
     pub agents_eject_threshold: u64,
     pub agent_fee: Coin,
     pub gas_price: u32,

--- a/packages/cw-croncat-core/src/msg.rs
+++ b/packages/cw-croncat-core/src/msg.rs
@@ -28,7 +28,7 @@ pub struct Croncat {
     config_response: Option<ConfigResponse>,
     balance_response: Option<BalancesResponse>,
     get_agent_ids_response: Option<GetAgentIdsResponse>,
-    get_agent_tasks_response: Option<GetAgentTasksResponse>,
+    get_agent_tasks_response: Option<AgentTaskResponse>,
     task_request: Option<TaskRequest>,
     task_response: Option<TaskResponse>,
 }
@@ -147,7 +147,7 @@ pub struct GetAgentIdsResponse {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct GetAgentTasksResponse {
+pub struct AgentTaskResponse {
     pub num_block_tasks: Uint64,
     pub num_cron_tasks: Uint64,
 }

--- a/packages/cw-croncat-core/src/msg.rs
+++ b/packages/cw-croncat-core/src/msg.rs
@@ -1,6 +1,6 @@
-use crate::types::Agent;
 use crate::types::{Action, Boundary, GenericBalance, Interval, Rule, Task};
-use cosmwasm_std::{Addr, Coin, Timestamp};
+use crate::types::{Agent, SlotType};
+use cosmwasm_std::{Addr, Coin, Timestamp, Uint64};
 use cw20::Balance;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -122,7 +122,7 @@ pub struct ConfigResponse {
     pub owner_id: Addr,
     // pub treasury_id: Option<Addr>,
     pub min_tasks_per_agent: u64,
-    pub agent_active_index: u64,
+    pub agent_active_indices: Vec<(SlotType, u32)>,
     pub agents_eject_threshold: u64,
     pub agent_fee: Coin,
     pub gas_price: u32,
@@ -147,7 +147,10 @@ pub struct GetAgentIdsResponse {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct GetAgentTasksResponse(pub u64, pub u64);
+pub struct GetAgentTasksResponse {
+    pub num_block_tasks: Uint64,
+    pub num_cron_tasks: Uint64,
+}
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct TaskRequest {

--- a/packages/cw-croncat-core/src/msg.rs
+++ b/packages/cw-croncat-core/src/msg.rs
@@ -149,9 +149,9 @@ pub struct GetAgentIdsResponse {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct AgentTaskResponse {
     pub num_block_tasks: Uint64,
-    pub num_block_tasks_extra:Uint64,
+    pub num_block_tasks_extra: Uint64,
     pub num_cron_tasks: Uint64,
-    pub num_cron_tasks_extra:Uint64,
+    pub num_cron_tasks_extra: Uint64,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/packages/cw-croncat-core/src/types.rs
+++ b/packages/cw-croncat-core/src/types.rs
@@ -99,7 +99,7 @@ pub struct Boundary {
     pub end: Option<BoundarySpec>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq, std::hash::Hash, Deserialize, Serialize, Clone, JsonSchema)]
 pub enum SlotType {
     Block,
     Cron,


### PR DESCRIPTION
More work needs to be done on `test_query_get_agent_tasks`, I believe.

Note that we're returning a tuple now when we want to get the agent tasks because we want to know how many block-based tasks and time-based tasks they can do.

I have NOT finished the implementation of the round-robin indices. (See Config's `agent_active_indices`) This basically needs to get finished and means that when there are "leftover" tasks, we make sure the extras go to different people.

So if there are 6 agents and 13 tasks, everyone gets 2 tasks, but then one person gets an extra 1 task. We don't want the first person in the active agent queue to **always** get that leftover task, so we have these indices that will let the first person get it… then the second… then the third…. And of course this applies if there are 6 agents and 14 tasks, where we'll have two agents getting the two extra tasks, and so on.