### PR TITLE
Fix pop_slot_item

### DIFF
--- a/contracts/cw-croncat/src/manager.rs
+++ b/contracts/cw-croncat/src/manager.rs
@@ -1201,7 +1201,7 @@ mod tests {
     }
 
     #[test]
-    fn c() -> StdResult<()> {
+    fn proxy_call_several_tasks() -> StdResult<()> {
         let (mut app, cw_template_contract) = proper_instantiate();
         let contract_addr = cw_template_contract.addr();
         let proxy_call_msg = ExecuteMsg::ProxyCall {};

--- a/contracts/cw-croncat/src/slots.rs
+++ b/contracts/cw-croncat/src/slots.rs
@@ -214,16 +214,13 @@ impl<'a> CwCroncat<'a> {
         // Need to remove this slot if no hash's left
         if slot_data.is_empty() {
             self.clean_slot(storage, slot, kind);
-        }
-
-        if hash.is_some() {
+        } else {
             store
                 .update(storage, *slot, |_d| -> StdResult<Vec<_>> { Ok(slot_data) })
                 .ok();
-            return hash;
         }
 
-        None
+        hash
     }
 
     // TODO: TestCov

--- a/contracts/cw-croncat/src/slots.rs
+++ b/contracts/cw-croncat/src/slots.rs
@@ -215,9 +215,7 @@ impl<'a> CwCroncat<'a> {
         if slot_data.is_empty() {
             self.clean_slot(storage, slot, kind);
         } else {
-            store
-                .update(storage, *slot, |_d| -> StdResult<Vec<_>> { Ok(slot_data) })
-                .ok();
+            store.save(storage, *slot, &slot_data).ok()?;
         }
 
         hash


### PR DESCRIPTION
For now, if we create several tasks and call `proxy_call`, it succeeds for the first time and fails if we try to call it again. 

It happens because these tasks are stored under separate keys in `block_slots: time_slots: Map<'a, u64, Vec<Vec<u8>>>` (or `time_slots`), and calling `pop_slot_item` should delete one of the keys, so that second `proxy_call` could take the remaining key and hash and execute the second task. Instead `pop_slot_item` leaves the first key with empty vector and the second `proxy_call` fails to get the correct `slot_id`.

That is why I think we should delete a key from `block_slots` (`time_slots`) if the corresponding vector of hashes is empty.

Also added a test, where three tasks are created and `proxy_call` is called on each of them.
