### PR TITLE
Tests coverage with tarpaulin

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,0 +1,23 @@
+name:                           coverage
+
+on:                             [push]
+
+jobs:
+  test:
+    name:                       coverage
+    runs-on:                    ubuntu-latest
+    container:
+      image:                    xd009642/tarpaulin:develop-nightly
+      options:                  --security-opt seccomp=unconfined
+    steps:
+      - name:                   Checkout repository
+        uses:                   actions/checkout@v2
+
+      - name:                   Generate code coverage
+        run: |
+          cargo +nightly tarpaulin --verbose --workspace --timeout 120 --out Xml
+  
+      - name:                   Upload to codecov.io
+        uses:                   codecov/codecov-action@v2
+        with:
+          fail_ci_if_error:     true


### PR DESCRIPTION
Closes #8
But before merging this give accesses to https://app.codecov.io/ I can also add badge in this PR, if you give me [repository graphing token](https://docs.codecov.com/reference/authorization#about-graphs) example:
[![codecov](https://codecov.io/gh/Buckram123/cw-croncat/branch/codecov/graph/badge.svg?token=BG5RGBNBH3)](https://codecov.io/gh/Buckram123/cw-croncat)