### PR TITLE
feat: estimate gas usage

### DIFF
--- a/contracts/cw-croncat/src/agent.rs
+++ b/contracts/cw-croncat/src/agent.rs
@@ -444,20 +444,20 @@ mod tests {
     fn mock_app() -> App {
         AppBuilder::new().build(|router, _, storage| {
             let accounts: Vec<(u128, String)> = vec![
-                (100, ADMIN.to_string()),
+                (2_000_000, ADMIN.to_string()),
                 (1, AGENT0.to_string()),
-                (100, AGENT1.to_string()),
-                (100, AGENT2.to_string()),
-                (100, AGENT3.to_string()),
-                (100, AGENT4.to_string()),
-                (20, PARTICIPANT0.to_string()),
-                (20, PARTICIPANT1.to_string()),
-                (20, PARTICIPANT2.to_string()),
-                (20, PARTICIPANT3.to_string()),
-                (20, PARTICIPANT4.to_string()),
-                (20, PARTICIPANT5.to_string()),
-                (20, PARTICIPANT6.to_string()),
-                (1, AGENT_BENEFICIARY.to_string()),
+                (2_000_000, AGENT1.to_string()),
+                (2_000_000, AGENT2.to_string()),
+                (2_000_000, AGENT3.to_string()),
+                (2_000_000, AGENT4.to_string()),
+                (500_0000, PARTICIPANT0.to_string()),
+                (500_0000, PARTICIPANT1.to_string()),
+                (500_0000, PARTICIPANT2.to_string()),
+                (500_0000, PARTICIPANT3.to_string()),
+                (500_0000, PARTICIPANT4.to_string()),
+                (500_0000, PARTICIPANT5.to_string()),
+                (500_0000, PARTICIPANT6.to_string()),
+                (2_000_000, AGENT_BENEFICIARY.to_string()),
             ];
             for (amt, address) in accounts.iter() {
                 router
@@ -480,6 +480,7 @@ mod tests {
         let msg = InstantiateMsg {
             denom: "atom".to_string(),
             owner_id: Some(owner_addr.clone()),
+            gas_base_fee: None,
             agent_nomination_duration: Some(360),
         };
         let cw_template_contract_addr = app
@@ -510,7 +511,7 @@ mod tests {
         let amount = coin(3, NATIVE_DENOM);
         let stake = StakingMsg::Delegate { validator, amount };
         let msg: CosmosMsg = stake.clone().into();
-        let send_funds = coins(1, NATIVE_DENOM);
+        let send_funds = coins(500_000, NATIVE_DENOM);
         app.execute_contract(
             Addr::unchecked(sender),
             contract_addr.clone(),
@@ -544,7 +545,7 @@ mod tests {
         let amount = coin(3, NATIVE_DENOM);
         let stake = StakingMsg::Delegate { validator, amount };
         let msg: CosmosMsg = stake.clone().into();
-        let send_funds = coins(1, NATIVE_DENOM);
+        let send_funds = coins(500_000, NATIVE_DENOM);
         app.execute_contract(
             Addr::unchecked(sender),
             contract_addr.clone(),
@@ -578,7 +579,7 @@ mod tests {
         let amount = coin(3, NATIVE_DENOM);
         let stake = StakingMsg::Delegate { validator, amount };
         let msg: CosmosMsg = stake.clone().into();
-        let send_funds = coins(1, NATIVE_DENOM);
+        let send_funds = coins(500_000, NATIVE_DENOM);
         app.execute_contract(
             Addr::unchecked(sender),
             contract_addr.clone(),
@@ -938,7 +939,7 @@ mod tests {
             .wrap()
             .query_balance(&Addr::unchecked(AGENT1), NATIVE_DENOM)
             .unwrap();
-        assert_eq!(agent_bal, coin(100, NATIVE_DENOM));
+        assert_eq!(agent_bal, coin(2_000_000, NATIVE_DENOM));
 
         // Attempt the unregister
         app.execute_contract(
@@ -974,7 +975,7 @@ mod tests {
             .wrap()
             .query_balance(&Addr::unchecked(AGENT1), NATIVE_DENOM)
             .unwrap();
-        assert_eq!(agent_bal, coin(100, NATIVE_DENOM));
+        assert_eq!(agent_bal, coin(2000000, NATIVE_DENOM));
     }
 
     #[test]
@@ -1009,7 +1010,7 @@ mod tests {
             .wrap()
             .query_balance(&Addr::unchecked(AGENT1), NATIVE_DENOM)
             .unwrap();
-        assert_eq!(agent_bal, coin(100, NATIVE_DENOM));
+        assert_eq!(agent_bal, coin(2_000_000, NATIVE_DENOM));
 
         // Attempt the withdraw
         app.execute_contract(
@@ -1026,7 +1027,7 @@ mod tests {
             .wrap()
             .query_balance(&Addr::unchecked(AGENT1), NATIVE_DENOM)
             .unwrap();
-        assert_eq!(agent_bal, coin(100, NATIVE_DENOM));
+        assert_eq!(agent_bal, coin(2_000_000, NATIVE_DENOM));
     }
 
     #[test]
@@ -1168,8 +1169,8 @@ mod tests {
         // Give the contract and the agents balances
         let mut deps = cosmwasm_std::testing::mock_dependencies_with_balances(&[
             (&MOCK_CONTRACT_ADDR, &[coin(6000, "atom")]),
-            (&AGENT0, &[coin(600, "atom")]),
-            (&AGENT1, &[coin(600, "atom")]),
+            (&AGENT0, &[coin(2_000_000, "atom")]),
+            (&AGENT1, &[coin(2_000_000, "atom")]),
         ]);
         let mut contract = CwCroncat::default();
 
@@ -1177,9 +1178,10 @@ mod tests {
         let msg = InstantiateMsg {
             denom: "atom".to_string(),
             owner_id: None,
+            gas_base_fee: None,
             agent_nomination_duration: Some(360),
         };
-        let mut info = mock_info(AGENT0, &coins(6000, "atom"));
+        let mut info = mock_info(AGENT0, &coins(900_000, "atom"));
         let res_init = contract
             .instantiate(deps.as_mut(), mock_env(), info.clone(), msg)
             .unwrap();

--- a/contracts/cw-croncat/src/balancer.rs
+++ b/contracts/cw-croncat/src/balancer.rs
@@ -158,6 +158,7 @@ impl<'a> Balancer<'a> for RoundRobinBalancer {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::contract::GAS_BASE_FEE_JUNO;
     use crate::error::ContractError;
     use crate::helpers::CwTemplateContract;
     use cosmwasm_std::testing::{
@@ -193,6 +194,7 @@ mod tests {
             staked_balance: GenericBalance::default(),
             agent_fee: Coin::new(5, NATIVE_DENOM.clone()), // TODO: CHANGE AMOUNT HERE!!! 0.0005 Juno (2000 tasks = 1 Juno)
             gas_price: 1,
+            gas_base_fee: GAS_BASE_FEE_JUNO,
             proxy_callback_gas: 3,
             slot_granularity: 60_000_000_000,
             native_denom: NATIVE_DENOM.to_owned(),

--- a/contracts/cw-croncat/src/contract.rs
+++ b/contracts/cw-croncat/src/contract.rs
@@ -15,6 +15,9 @@ const CONTRACT_NAME: &str = "crates.io:cw-croncat";
 const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 const DEFAULT_NOMINATION_DURATION: u16 = 360;
 
+// default for juno
+pub(crate) const GAS_BASE_FEE_JUNO: u64 = 400_000;
+
 // #[cfg(not(feature = "library"))]
 impl<'a> CwCroncat<'a> {
     pub fn instantiate(
@@ -37,6 +40,12 @@ impl<'a> CwCroncat<'a> {
             "Invalid address"
         );
 
+        let gas_base_fee = if let Some(base_fee) = msg.gas_base_fee {
+            base_fee.u64()
+        } else {
+            GAS_BASE_FEE_JUNO
+        };
+
         let config = Config {
             paused: false,
             owner_id: owner_acct,
@@ -49,6 +58,7 @@ impl<'a> CwCroncat<'a> {
             agent_fee: Coin::new(5, msg.denom.clone()), // TODO: CHANGE AMOUNT HERE!!! 0.0005 Juno (2000 tasks = 1 Juno)
             gas_price: 1,
             proxy_callback_gas: 3,
+            gas_base_fee,
             slot_granularity: 60_000_000_000,
             native_denom: msg.denom,
             cw20_whitelist: vec![],
@@ -209,6 +219,7 @@ mod tests {
         let msg = InstantiateMsg {
             denom: "atom".to_string(),
             owner_id: None,
+            gas_base_fee: None,
             agent_nomination_duration: Some(360),
         };
         let info = mock_info("creator", &coins(1000, "meow"));

--- a/contracts/cw-croncat/src/helpers.rs
+++ b/contracts/cw-croncat/src/helpers.rs
@@ -203,6 +203,7 @@ pub mod test_helpers {
         let msg = InstantiateMsg {
             denom: "atom".to_string(),
             owner_id: None,
+            gas_base_fee: None,
             agent_nomination_duration: Some(360),
         };
         let info = mock_info("creator", &coins(1000, "meow"));

--- a/contracts/cw-croncat/src/manager.rs
+++ b/contracts/cw-croncat/src/manager.rs
@@ -373,10 +373,10 @@ mod tests {
     fn mock_app() -> App {
         AppBuilder::new().build(|router, _, storage| {
             let accounts: Vec<(u128, String)> = vec![
-                (100, ADMIN.to_string()),
-                (100, ANYONE.to_string()),
-                (100, AGENT0.to_string()),
-                (100, AGENT1_BENEFICIARY.to_string()),
+                (6_000_000, ADMIN.to_string()),
+                (500_000, ANYONE.to_string()),
+                (2_000_000, AGENT0.to_string()),
+                (2_000_000, AGENT1_BENEFICIARY.to_string()),
             ];
             for (amt, address) in accounts.iter() {
                 router
@@ -399,6 +399,7 @@ mod tests {
         let msg = InstantiateMsg {
             denom: NATIVE_DENOM.to_string(),
             owner_id: Some(owner_addr.clone()),
+            gas_base_fee: None,
             agent_nomination_duration: None,
         };
         let cw_template_contract_addr = app
@@ -407,7 +408,7 @@ mod tests {
                 cw_template_id,
                 owner_addr,
                 &msg,
-                &coins(6, NATIVE_DENOM),
+                &coins(2_000_000, NATIVE_DENOM),
                 "Manager",
                 None,
             )
@@ -464,7 +465,7 @@ mod tests {
                 Addr::unchecked(ANYONE),
                 contract_addr.clone(),
                 &proxy_call_msg,
-                &coins(1, NATIVE_DENOM),
+                &coins(300010, NATIVE_DENOM),
             )
             .unwrap_err();
         assert_eq!(
@@ -553,7 +554,7 @@ mod tests {
                 Addr::unchecked(ANYONE),
                 contract_addr.clone(),
                 &create_task_msg,
-                &coins(1, NATIVE_DENOM),
+                &coins(300010, NATIVE_DENOM),
             )
             .unwrap();
         // Assert task hash is returned as part of event attributes
@@ -655,7 +656,7 @@ mod tests {
                 Addr::unchecked(ADMIN),
                 contract_addr.clone(),
                 &create_task_msg,
-                &coins(10, NATIVE_DENOM),
+                &coins(500010, NATIVE_DENOM),
             )
             .unwrap();
         // Assert task hash is returned as part of event attributes
@@ -787,7 +788,7 @@ mod tests {
                 Addr::unchecked(ADMIN),
                 contract_addr.clone(),
                 &create_task_msg,
-                &coins(10, NATIVE_DENOM),
+                &coins(500010, NATIVE_DENOM),
             )
             .unwrap();
         // Assert task hash is returned as part of event attributes
@@ -849,7 +850,7 @@ mod tests {
                     }
                     if e.ty == "transfer"
                         && a.clone().key == "amount"
-                        && a.clone().value == "10atom"
+                        && a.clone().value == "500010atom"
                     {
                         has_submsg_method = true;
                     }
@@ -909,7 +910,7 @@ mod tests {
             Addr::unchecked(ADMIN),
             contract_addr.clone(),
             &create_task_msg,
-            &coins(10, NATIVE_DENOM),
+            &coins(500010, NATIVE_DENOM),
         )
         .unwrap();
 
@@ -946,7 +947,7 @@ mod tests {
                     }
                     if e.ty == "transfer"
                         && a.clone().key == "amount"
-                        && a.clone().value == "10atom"
+                        && a.clone().value == "500010atom"
                     {
                         has_submsg_method = true;
                     }
@@ -1016,7 +1017,7 @@ mod tests {
                 Addr::unchecked(ADMIN),
                 contract_addr.clone(),
                 &create_task_msg,
-                &coins(10, NATIVE_DENOM),
+                &coins(500010, NATIVE_DENOM),
             )
             .unwrap();
         // Assert task hash is returned as part of event attributes
@@ -1148,7 +1149,7 @@ mod tests {
                 Addr::unchecked(ADMIN),
                 contract_addr.clone(),
                 &create_task_msg,
-                &coins(10, NATIVE_DENOM),
+                &coins(500010, NATIVE_DENOM),
             )
             .unwrap();
         // Assert task hash is returned as part of event attributes
@@ -1321,7 +1322,7 @@ mod tests {
             Addr::unchecked(ADMIN),
             contract_addr.clone(),
             &create_task_msg,
-            &coins(10, NATIVE_DENOM),
+            &coins(500_010, NATIVE_DENOM),
         )
         .unwrap();
 
@@ -1329,7 +1330,7 @@ mod tests {
             Addr::unchecked(ADMIN),
             contract_addr.clone(),
             &create_task_msg2,
-            &coins(10, NATIVE_DENOM),
+            &coins(500_010, NATIVE_DENOM),
         )
         .unwrap();
 
@@ -1340,7 +1341,7 @@ mod tests {
             Addr::unchecked(ADMIN),
             contract_addr.clone(),
             &create_task_msg3,
-            &coins(10, NATIVE_DENOM),
+            &coins(500_010, NATIVE_DENOM),
         )
         .unwrap();
 

--- a/contracts/cw-croncat/src/owner.rs
+++ b/contracts/cw-croncat/src/owner.rs
@@ -263,6 +263,7 @@ mod tests {
         let msg = InstantiateMsg {
             denom: "atom".to_string(),
             owner_id: None,
+            gas_base_fee: None,
             agent_nomination_duration: Some(360),
         };
         let info = MessageInfo {
@@ -339,6 +340,7 @@ mod tests {
         let msg = InstantiateMsg {
             denom: "atom".to_string(),
             owner_id: None,
+            gas_base_fee: None,
             agent_nomination_duration: Some(360),
         };
         let res_init = store
@@ -399,6 +401,7 @@ mod tests {
         let msg = InstantiateMsg {
             denom: "atom".to_string(),
             owner_id: None,
+            gas_base_fee: None,
             agent_nomination_duration: Some(360),
         };
         let res_init = store

--- a/contracts/cw-croncat/src/state.rs
+++ b/contracts/cw-croncat/src/state.rs
@@ -32,6 +32,7 @@ pub struct Config {
     // Economics
     pub agent_fee: Coin,
     pub gas_price: u32,
+    pub gas_base_fee: u64,
     pub proxy_callback_gas: u32,
     pub slot_granularity: u64,
 

--- a/contracts/cw-croncat/src/tasks.rs
+++ b/contracts/cw-croncat/src/tasks.rs
@@ -518,7 +518,7 @@ mod tests {
         AppBuilder::new().build(|router, _, storage| {
             let accounts: Vec<(u128, String)> = vec![
                 (100, ADMIN.to_string()),
-                (600023, ANYONE.to_string()),
+                (800_010, ANYONE.to_string()),
                 (u128::max_value(), VERY_RICH.to_string()),
             ];
             for (amt, address) in accounts.iter() {
@@ -1368,11 +1368,12 @@ mod tests {
             },
         };
         // create 1 token off task
+        let amount_for_one_task = gas_limit + agent_fee;
         let res = app.execute_contract(
             Addr::unchecked(ANYONE),
             contract_addr.clone(),
             &create_task_msg,
-            &coins(u128::from(gas_limit + agent_fee - 1), "atom"),
+            &coins(u128::from(amount_for_one_task * 2 - 1), "atom"),
         );
         assert!(format!("{res:?}").contains("Not enough task balance to execute job"));
 
@@ -1381,7 +1382,7 @@ mod tests {
             Addr::unchecked(ANYONE),
             contract_addr.clone(),
             &create_task_msg,
-            &coins(u128::from(gas_limit + agent_fee), "atom"),
+            &coins(u128::from(amount_for_one_task * 2), "atom"),
         );
         assert!(res.is_ok());
     }
@@ -1414,11 +1415,12 @@ mod tests {
             },
         };
         // create 1 token off task
+        let amount_for_one_task = gas_limit + agent_fee;
         let res = app.execute_contract(
             Addr::unchecked(ANYONE),
             contract_addr.clone(),
             &create_task_msg,
-            &coins(u128::from(gas_limit + agent_fee - 1), "atom"),
+            &coins(u128::from(amount_for_one_task * 2 - 1), "atom"),
         );
         assert!(format!("{res:?}").contains("Not enough task balance to execute job"));
 
@@ -1427,7 +1429,7 @@ mod tests {
             Addr::unchecked(ANYONE),
             contract_addr.clone(),
             &create_task_msg,
-            &coins(u128::from(gas_limit + agent_fee), "atom"),
+            &coins(u128::from(amount_for_one_task * 2), "atom"),
         );
         assert!(res.is_ok());
     }

--- a/contracts/cw-croncat/src/tasks.rs
+++ b/contracts/cw-croncat/src/tasks.rs
@@ -244,19 +244,27 @@ impl<'a> CwCroncat<'a> {
             });
         }
 
-        // TODO:
         // // Check that balance is sufficient for 1 execution minimum
-        // let call_balance_used = self.task_balance_uses(&item);
-        // let min_balance_needed: u128 = if recurring == Some(true) {
-        //     call_balance_used * 2
-        // } else {
-        //     call_balance_used
-        // };
-        // assert!(
-        //     min_balance_needed <= item.total_deposit.0,
-        //     "Not enough task balance to execute job, need at least {}",
-        //     min_balance_needed
-        // );
+        let call_balance_used = item.task_balance_uses(&c.agent_fee, c.gas_base_fee);
+        let min_balance_needed: u128 =
+            if item.interval != Interval::Once && item.interval != Interval::Immediate {
+                call_balance_used * 2
+            } else {
+                call_balance_used
+            };
+        let attached_native = item
+            .total_deposit
+            .iter()
+            .find(|coin| coin.denom == c.native_denom)
+            .map(|c| c.amount.u128())
+            .unwrap_or_default();
+        if attached_native < min_balance_needed {
+            return Err(ContractError::CustomError {
+                val: format!(
+                    "Not enough task balance to execute job, need at least {min_balance_needed}, attached: {attached_native}",
+                ),
+            });
+        }
 
         let hash = item.to_hash();
 
@@ -315,7 +323,7 @@ impl<'a> CwCroncat<'a> {
         }
 
         // Add the attached balance into available_balance
-        let mut c: Config = self.config.load(deps.storage)?;
+        let mut c: Config = c;
         c.available_balance.add_tokens(Balance::from(info.funds));
 
         // If the creation of this task means we'd like another agent, update config
@@ -483,6 +491,7 @@ mod tests {
 
     use std::convert::TryInto;
     // use cosmwasm_std::testing::MockStorage;
+    use crate::contract::GAS_BASE_FEE_JUNO;
     use cosmwasm_std::{
         coin, coins, to_binary, Addr, BankMsg, CosmosMsg, Empty, StakingMsg, WasmMsg,
     };
@@ -510,7 +519,7 @@ mod tests {
         AppBuilder::new().build(|router, _, storage| {
             let accounts: Vec<(u128, String)> = vec![
                 (100, ADMIN.to_string()),
-                (100, ANYONE.to_string()),
+                (600023, ANYONE.to_string()),
                 (u128::max_value(), VERY_RICH.to_string()),
             ];
             for (amt, address) in accounts.iter() {
@@ -534,6 +543,7 @@ mod tests {
         let msg = InstantiateMsg {
             denom: "atom".to_string(),
             owner_id: Some(owner_addr.clone()),
+            gas_base_fee: None,
             agent_nomination_duration: Some(360),
         };
         let cw_template_contract_addr = app
@@ -643,7 +653,7 @@ mod tests {
             Addr::unchecked(ANYONE),
             contract_addr.clone(),
             &create_task_msg,
-            &coins(37, "atom"),
+            &coins(300010, "atom"),
         )
         .unwrap();
 
@@ -707,7 +717,7 @@ mod tests {
                 Addr::unchecked(VERY_RICH),
                 contract_addr.clone(),
                 &new_msg(amount),
-                &coins(37, "atom"),
+                &coins(300010, "atom"),
             )
             .unwrap();
         }
@@ -895,7 +905,7 @@ mod tests {
                 Addr::unchecked(ANYONE),
                 contract_addr.clone(),
                 &create_task_msg,
-                &coins(13, "atom"),
+                &coins(300010, "atom"),
             )
             .unwrap_err();
         assert_eq!(
@@ -993,7 +1003,7 @@ mod tests {
             Addr::unchecked(ANYONE),
             contract_addr.clone(),
             &create_task_msg,
-            &coins(13, "atom"),
+            &coins(300010, "atom"),
         )
         .unwrap();
         let res_err = app
@@ -1001,7 +1011,7 @@ mod tests {
                 Addr::unchecked(ANYONE),
                 contract_addr.clone(),
                 &create_task_msg,
-                &coins(13, "atom"),
+                &coins(300010, "atom"),
             )
             .unwrap_err();
         assert_eq!(
@@ -1031,7 +1041,7 @@ mod tests {
                         rules: None,
                     },
                 },
-                &coins(13, "atom"),
+                &coins(300010, "atom"),
             )
             .unwrap_err();
         assert_eq!(
@@ -1080,7 +1090,7 @@ mod tests {
                 Addr::unchecked(ANYONE),
                 contract_addr.clone(),
                 &create_task_msg,
-                &coins(37, "atom"),
+                &coins(300010, "atom"),
             )
             .unwrap();
         // Assert task hash is returned as part of event attributes
@@ -1116,7 +1126,7 @@ mod tests {
                 t.boundary
             );
             assert_eq!(false, t.stop_on_fail);
-            assert_eq!(coins(37, "atom"), t.total_deposit);
+            assert_eq!(coins(300010, "atom"), t.total_deposit);
             assert_eq!(task_id_str.clone(), t.task_hash);
         }
 
@@ -1179,7 +1189,7 @@ mod tests {
             Addr::unchecked(ANYONE),
             contract_addr.clone(),
             &create_task_msg,
-            &coins(37, "atom"),
+            &coins(300010, "atom"),
         )
         .unwrap();
 
@@ -1279,7 +1289,7 @@ mod tests {
             Addr::unchecked(ANYONE),
             contract_addr.clone(),
             &create_task_msg,
-            &coins(37, "atom"),
+            &coins(300010, "atom"),
         )
         .unwrap();
         // refill task
@@ -1297,7 +1307,7 @@ mod tests {
         let mut matches_new_totals: bool = false;
         for e in res.events {
             for a in e.attributes {
-                if a.key == "total_deposit" && a.value == "40atom".to_string() {
+                if a.key == "total_deposit" && a.value == "300013atom".to_string() {
                     matches_new_totals = true;
                 }
             }
@@ -1318,7 +1328,7 @@ mod tests {
 
         if let Some(t) = new_task {
             assert_eq!(Addr::unchecked(ANYONE), t.owner_id);
-            assert_eq!(coins(40, "atom"), t.total_deposit);
+            assert_eq!(coins(300013, "atom"), t.total_deposit);
         }
 
         // Check the balance has increased to include the new refilled total
@@ -1326,8 +1336,100 @@ mod tests {
             .wrap()
             .query_wasm_smart(&contract_addr.clone(), &QueryMsg::GetBalances {})
             .unwrap();
-        assert_eq!(coins(40, "atom"), balances.available_balance.native);
+        assert_eq!(coins(300013, "atom"), balances.available_balance.native);
 
         Ok(())
+    }
+
+    #[test]
+    fn check_gas_minimum() {
+        let (mut app, cw_template_contract) = proper_instantiate();
+        let contract_addr = cw_template_contract.addr();
+
+        let validator = String::from("you");
+        let amount = coin(3, "atom");
+        let stake = StakingMsg::Delegate { validator, amount };
+        let msg: CosmosMsg = stake.clone().into();
+        let gas_limit = 150_000;
+        let agent_fee = 5;
+
+        let create_task_msg = ExecuteMsg::CreateTask {
+            task: TaskRequest {
+                interval: Interval::Immediate,
+                boundary: Boundary {
+                    start: None,
+                    end: None,
+                },
+                stop_on_fail: false,
+                actions: vec![Action {
+                    msg,
+                    gas_limit: Some(gas_limit),
+                }],
+                rules: None,
+            },
+        };
+        // create 1 token off task
+        let res = app.execute_contract(
+            Addr::unchecked(ANYONE),
+            contract_addr.clone(),
+            &create_task_msg,
+            &coins(u128::from(gas_limit + agent_fee - 1), "atom"),
+        );
+        assert!(format!("{res:?}").contains("Not enough task balance to execute job"));
+
+        // create a task
+        let res = app.execute_contract(
+            Addr::unchecked(ANYONE),
+            contract_addr.clone(),
+            &create_task_msg,
+            &coins(u128::from(gas_limit + agent_fee), "atom"),
+        );
+        assert!(res.is_ok());
+    }
+
+    #[test]
+    fn check_gas_default() {
+        let (mut app, cw_template_contract) = proper_instantiate();
+        let contract_addr = cw_template_contract.addr();
+
+        let validator = String::from("you");
+        let amount = coin(3, "atom");
+        let stake = StakingMsg::Delegate { validator, amount };
+        let msg: CosmosMsg = stake.clone().into();
+        let gas_limit = GAS_BASE_FEE_JUNO;
+        let agent_fee = 5;
+
+        let create_task_msg = ExecuteMsg::CreateTask {
+            task: TaskRequest {
+                interval: Interval::Immediate,
+                boundary: Boundary {
+                    start: None,
+                    end: None,
+                },
+                stop_on_fail: false,
+                actions: vec![Action {
+                    msg,
+                    gas_limit: None,
+                }],
+                rules: None,
+            },
+        };
+        // create 1 token off task
+        let res = app.execute_contract(
+            Addr::unchecked(ANYONE),
+            contract_addr.clone(),
+            &create_task_msg,
+            &coins(u128::from(gas_limit + agent_fee - 1), "atom"),
+        );
+        assert!(format!("{res:?}").contains("Not enough task balance to execute job"));
+
+        // create a task
+        let res = app.execute_contract(
+            Addr::unchecked(ANYONE),
+            contract_addr.clone(),
+            &create_task_msg,
+            &coins(u128::from(gas_limit + agent_fee), "atom"),
+        );
+        assert!(res.is_ok());
     }
 }

--- a/contracts/cw-croncat/src/tasks.rs
+++ b/contracts/cw-croncat/src/tasks.rs
@@ -246,12 +246,11 @@ impl<'a> CwCroncat<'a> {
 
         // // Check that balance is sufficient for 1 execution minimum
         let call_balance_used = item.task_balance_uses(&c.agent_fee, c.gas_base_fee);
-        let min_balance_needed: u128 =
-            if item.interval != Interval::Once && item.interval != Interval::Immediate {
-                call_balance_used * 2
-            } else {
-                call_balance_used
-            };
+        let min_balance_needed: u128 = if item.interval != Interval::Once {
+            call_balance_used * 2
+        } else {
+            call_balance_used
+        };
         let attached_native = item
             .total_deposit
             .iter()

--- a/packages/cw-croncat-core/schema/instantiate_msg.json
+++ b/packages/cw-croncat-core/schema/instantiate_msg.json
@@ -17,6 +17,16 @@
     "denom": {
       "type": "string"
     },
+    "gas_base_fee": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Uint64"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "owner_id": {
       "anyOf": [
         {
@@ -31,6 +41,10 @@
   "definitions": {
     "Addr": {
       "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+      "type": "string"
+    },
+    "Uint64": {
+      "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
       "type": "string"
     }
   }

--- a/packages/cw-croncat-core/src/msg.rs
+++ b/packages/cw-croncat-core/src/msg.rs
@@ -54,6 +54,7 @@ pub struct InstantiateMsg {
     // TODO: Submit issue for AppBuilder tests not working for -- deps.querier.query_bonded_denom()?;
     pub denom: String,
     pub owner_id: Option<Addr>,
+    pub gas_base_fee: Option<Uint64>,
     pub agent_nomination_duration: Option<u16>,
 }
 

--- a/packages/cw-croncat-core/src/types.rs
+++ b/packages/cw-croncat-core/src/types.rs
@@ -175,9 +175,15 @@ impl Task {
     }
     // /// Returns the base amount required to execute 1 task
     // /// NOTE: this is not the final used amount, just the user-specified amount total needed
-    // pub fn task_balance_uses(&self, task: &Task) -> u128 {
-    //     task.deposit.0 + (u128::from(task.gas) * self.gas_price) + self.agent_fee
-    // }
+    pub fn task_balance_uses(&self, agent_fee: &Coin, gas_base_fee: u64) -> u128 {
+        // TODO support attaching funds
+        // task.deposit.0 +
+        self.actions
+            .iter()
+            .fold(agent_fee.amount.u128(), |sum, action| {
+                sum + u128::from(action.gas_limit.unwrap_or(gas_base_fee))
+            })
+    }
 
     /// Validate the task actions only use the supported messages
     pub fn is_valid_msg(&self, self_addr: &Addr, sender: &Addr, owner_id: &Addr) -> bool {

--- a/types/contract/CwCroncatContract.ts
+++ b/types/contract/CwCroncatContract.ts
@@ -378,6 +378,7 @@ export type GetTasksResponse = TaskResponse[];
 export interface InstantiateMsg {
   agent_nomination_duration?: number | null;
   denom: string;
+  gas_base_fee?: Uint64 | null;
   owner_id?: Addr | null;
   [k: string]: unknown;
 }


### PR DESCRIPTION
Closes #25
So I was just checking how much gas single contract-tx can take, and I think around 400,000 is a good approximate.

Pretty sure we should also add coverage on `proxy_call` itself besides tasks. I think it's better done after we play more with it on mainnet/testnet.