### PR TITLE
Modify is_valid_msg so preliminary Bank msg werks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -214,6 +223,7 @@ dependencies = [
  "cw20",
  "cw20-base",
  "hex",
+ "regex",
  "schemars",
  "serde",
  "sha2",
@@ -668,6 +678,23 @@ checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
  "getrandom 0.2.6",
 ]
+
+[[package]]
+name = "regex"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "rfc6979"

--- a/contracts/cw-croncat/Cargo.toml
+++ b/contracts/cw-croncat/Cargo.toml
@@ -44,6 +44,8 @@ serde = { version = "1.0", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0" }
 hex = "0.4"
 sha2 = "0.9"
+regex = "1"
+
 
 [dev-dependencies]
 cosmwasm-schema = { version = "1.0.0" }

--- a/contracts/cw-croncat/src/agent.rs
+++ b/contracts/cw-croncat/src/agent.rs
@@ -64,6 +64,7 @@ impl<'a> CwCroncat<'a> {
 
     // TODO: Change this to solid round-table implementation. Setup this simple version for PoC
     /// Get how many tasks an agent can execute
+    /// TODO: Remove this function, replaced by balancer
     pub(crate) fn query_get_agent_tasks(
         &mut self,
         deps: Deps,

--- a/contracts/cw-croncat/src/helpers.rs
+++ b/contracts/cw-croncat/src/helpers.rs
@@ -1,7 +1,10 @@
 use crate::state::Config;
 use crate::ContractError::AgentNotRegistered;
 use crate::{ContractError, CwCroncat};
-use cosmwasm_std::{to_binary, Addr, BankMsg, CosmosMsg, Env, StdResult, Storage, SubMsg, WasmMsg};
+use cosmwasm_std::{
+    to_binary, Addr, BankMsg, Coin, CosmosMsg, Env, StdResult, Storage, SubMsg, SubMsgResult,
+    WasmMsg,
+};
 use cw20::{Cw20CoinVerified, Cw20ExecuteMsg};
 use cw_croncat_core::msg::ExecuteMsg;
 use cw_croncat_core::types::AgentStatus;
@@ -76,6 +79,37 @@ pub(crate) fn has_cw_coins(coins: &[Cw20CoinVerified], required: &Cw20CoinVerifi
         .find(|c| c.address == required.address)
         .map(|m| m.amount >= required.amount)
         .unwrap_or(false)
+}
+pub trait ReplyMsgParser {
+    fn transferred_bank_tokens(&self) -> Vec<cosmwasm_std::Coin>;
+}
+impl ReplyMsgParser for cosmwasm_std::Reply {
+    fn transferred_bank_tokens(&self) -> Vec<cosmwasm_std::Coin> {
+        if let SubMsgResult::Ok(res) = &self.result {
+            res.events
+                .iter()
+                .filter(|ev| ev.ty == "transfer")
+                .flat_map(|ev| {
+                    ev.attributes
+                        .iter()
+                        .filter_map(|attr| {
+                            attr.key.eq("amount").then(|| {
+                                // I really don't want to put regex here, it's gonna increase binary size way too much
+                                let n = attr.value.chars().position(|c| c.is_alphabetic()).unwrap();
+                                let (amount, denom) = attr.value.split_at(n);
+                                Coin {
+                                    amount: amount.parse().unwrap(),
+                                    denom: denom.to_owned(),
+                                }
+                            })
+                        })
+                        .collect::<Vec<Coin>>()
+                })
+                .collect()
+        } else {
+            Vec::new()
+        }
+    }
 }
 
 impl<'a> CwCroncat<'a> {

--- a/contracts/cw-croncat/src/helpers.rs
+++ b/contracts/cw-croncat/src/helpers.rs
@@ -1,4 +1,3 @@
-use std::str::FromStr;
 use crate::state::Config;
 use crate::ContractError::AgentNotRegistered;
 use crate::{ContractError, CwCroncat};
@@ -14,6 +13,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::cmp;
 use std::ops::Div;
+use std::str::FromStr;
 pub(crate) fn vect_difference<T: std::clone::Clone + std::cmp::PartialEq>(
     v1: &[T],
     v2: &[T],
@@ -21,13 +21,13 @@ pub(crate) fn vect_difference<T: std::clone::Clone + std::cmp::PartialEq>(
     v1.iter().filter(|&x| !v2.contains(x)).cloned().collect()
 }
 
-pub(crate) fn from_raw_str(value: &str) -> Coin {
+pub(crate) fn from_raw_str(value: &str) -> Option<Coin> {
     let re = Regex::new(r"^([0-9.]+)([a-z][a-z0-9]*)$").unwrap();
     assert!(re.is_match(value));
-    let caps = re.captures(value).unwrap();
+    let caps = re.captures(value)?;
     let amount = caps.get(1).map_or("", |m| m.as_str());
     let denom = caps.get(2).map_or("", |m| m.as_str());
-    Coin::new(u128::from_str(amount).unwrap(), denom)
+    Some(Coin::new(u128::from_str(amount).unwrap(), denom))
 }
 // Helper to distribute funds/tokens
 pub(crate) fn send_tokens(

--- a/contracts/cw-croncat/src/helpers.rs
+++ b/contracts/cw-croncat/src/helpers.rs
@@ -1,19 +1,17 @@
 use crate::state::Config;
 use crate::ContractError::AgentNotRegistered;
 use crate::{ContractError, CwCroncat};
-use cosmwasm_std::{
-    to_binary, Addr, BankMsg, Coin, CosmosMsg, Env, StdResult, Storage, SubMsg, WasmMsg,
-};
+use cosmwasm_std::{to_binary, Addr, BankMsg, CosmosMsg, Env, StdResult, Storage, SubMsg, WasmMsg};
 use cw20::{Cw20CoinVerified, Cw20ExecuteMsg};
 use cw_croncat_core::msg::ExecuteMsg;
 use cw_croncat_core::types::AgentStatus;
 pub use cw_croncat_core::types::{GenericBalance, Task};
-use regex::Regex;
+//use regex::Regex;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::cmp;
 use std::ops::Div;
-use std::str::FromStr;
+//use std::str::FromStr;
 pub(crate) fn vect_difference<T: std::clone::Clone + std::cmp::PartialEq>(
     v1: &[T],
     v2: &[T],
@@ -21,15 +19,16 @@ pub(crate) fn vect_difference<T: std::clone::Clone + std::cmp::PartialEq>(
     v1.iter().filter(|&x| !v2.contains(x)).cloned().collect()
 }
 
-pub(crate) fn from_raw_str(value: &str) -> Option<Coin> {
-    let re = Regex::new(r"^([0-9.]+)([a-z][a-z0-9]*)$").unwrap();
-    assert!(re.is_match(value));
-    let caps = re.captures(value)?;
-    let amount = caps.get(1).map_or("", |m| m.as_str());
-    let denom = caps.get(2).map_or("", |m| m.as_str());
-    assert!(denom.len() < 3 || denom.len() > 128);
-    Some(Coin::new(u128::from_str(amount).unwrap(), denom))
-}
+// pub(crate) fn from_raw_str(value: &str) -> Option<Coin> {
+//     let re = Regex::new(r"^([0-9.]+)([a-z][a-z0-9]*)$").unwrap();
+//     assert!(re.is_match(value));
+//     let caps = re.captures(value)?;
+//     let amount = caps.get(1).map_or("", |m| m.as_str());
+//     let denom = caps.get(2).map_or("", |m| m.as_str());
+//     assert!(denom.len() < 3 || denom.len() > 128);
+//     Some(Coin::new(u128::from_str(amount).unwrap(), denom))
+// }
+
 // Helper to distribute funds/tokens
 pub(crate) fn send_tokens(
     to: &Addr,

--- a/contracts/cw-croncat/src/helpers.rs
+++ b/contracts/cw-croncat/src/helpers.rs
@@ -21,7 +21,6 @@ pub(crate) fn vect_difference<T: std::clone::Clone + std::cmp::PartialEq>(
     v1.iter().filter(|&x| !v2.contains(x)).cloned().collect()
 }
 
-
 pub(crate) fn from_raw_str(value: &str) -> Option<Coin> {
     let re = Regex::new(r"^([0-9.]+)([a-z][a-z0-9]*)$").unwrap();
     assert!(re.is_match(value));

--- a/contracts/cw-croncat/src/helpers.rs
+++ b/contracts/cw-croncat/src/helpers.rs
@@ -21,12 +21,14 @@ pub(crate) fn vect_difference<T: std::clone::Clone + std::cmp::PartialEq>(
     v1.iter().filter(|&x| !v2.contains(x)).cloned().collect()
 }
 
+
 pub(crate) fn from_raw_str(value: &str) -> Option<Coin> {
     let re = Regex::new(r"^([0-9.]+)([a-z][a-z0-9]*)$").unwrap();
     assert!(re.is_match(value));
     let caps = re.captures(value)?;
     let amount = caps.get(1).map_or("", |m| m.as_str());
     let denom = caps.get(2).map_or("", |m| m.as_str());
+    assert!(denom.len() < 3 || denom.len() > 128);
     Some(Coin::new(u128::from_str(amount).unwrap(), denom))
 }
 // Helper to distribute funds/tokens

--- a/contracts/cw-croncat/src/helpers.rs
+++ b/contracts/cw-croncat/src/helpers.rs
@@ -25,7 +25,9 @@ pub(crate) fn vect_difference<T: std::clone::Clone + std::cmp::PartialEq>(
 //     let caps = re.captures(value)?;
 //     let amount = caps.get(1).map_or("", |m| m.as_str());
 //     let denom = caps.get(2).map_or("", |m| m.as_str());
-//     assert!(denom.len() < 3 || denom.len() > 128);
+//     if denom.len() < 3 || denom.len() > 128{
+//         return Option::None;
+//     }
 //     Some(Coin::new(u128::from_str(amount).unwrap(), denom))
 // }
 

--- a/contracts/cw-croncat/src/manager.rs
+++ b/contracts/cw-croncat/src/manager.rs
@@ -97,6 +97,7 @@ impl<'a> CwCroncat<'a> {
 
         //Restrict bank msg so contract doesnt get drained
         if task.is_reccuring()
+            && task.contains_send_msg()
             && !task.is_valid_msg(&env.contract.address, &info.sender, &c.owner_id)
         {
             return Err(ContractError::CustomError {

--- a/contracts/cw-croncat/src/manager.rs
+++ b/contracts/cw-croncat/src/manager.rs
@@ -1485,7 +1485,7 @@ mod tests {
             &create_task_msg,
             &coins(u128::from(amount_for_one_task * 2), "atom"),
         );
-        assert!(res.is_err());//Will fail, abount of send > then task.total_deposit
+        assert!(res.is_err()); //Will fail, abount of send > then task.total_deposit
 
         // quick agent register
         let msg = ExecuteMsg::RegisterAgent {

--- a/contracts/cw-croncat/src/manager.rs
+++ b/contracts/cw-croncat/src/manager.rs
@@ -96,7 +96,7 @@ impl<'a> CwCroncat<'a> {
         let task = some_task.unwrap();
 
         //Restrict bank msg so contract doesnt get drained
-        if task.is_reccuring()
+        if task.is_recurring()
             && task.contains_send_msg()
             && !task.is_valid_msg(&env.contract.address, &info.sender, &c.owner_id)
         {
@@ -280,7 +280,7 @@ impl<'a> CwCroncat<'a> {
                 return Ok(response);
             } else {
                 //If Send and reccuring task increment withdrawn funds so contract doesnt get drained
-                if task.contains_send_msg() && task.is_reccuring() {
+                if task.contains_send_msg() && task.is_recurring() {
                     //task.funds_withdrawn_recurring.saturating_add(msg..funds[0].amount);
                     self.tasks.save(deps.storage, task_hash, &task)?;
                 }

--- a/contracts/cw-croncat/src/manager.rs
+++ b/contracts/cw-croncat/src/manager.rs
@@ -1,7 +1,9 @@
 use crate::error::ContractError;
+use crate::helpers::ReplyMsgParser;
 use crate::state::{Config, CwCroncat, QueueItem};
 use cosmwasm_std::{
     Addr, DepsMut, Empty, Env, MessageInfo, Reply, Response, StdResult, Storage, SubMsg,
+    SubMsgResult,
 };
 use cw20::Balance;
 use cw_croncat_core::traits::Intervals;
@@ -228,18 +230,15 @@ impl<'a> CwCroncat<'a> {
 
         // check if reply had failure
         let mut reply_submsg_failed = false;
-        if msg.result.is_ok() {
-            for e in msg.result.unwrap().events {
-                for a in e.attributes {
-                    if e.ty == "reply"
-                        && a.clone().key == "mode"
-                        && a.clone().value == "handle_failure"
-                    {
+        if let SubMsgResult::Ok(response) = &msg.result {
+            for e in &response.events {
+                for a in &e.attributes {
+                    if e.ty == "reply" && a.key == "mode" && a.value == "handle_failure" {
                         reply_submsg_failed = true;
                     }
                 }
             }
-        } else if msg.result.is_err() {
+        } else {
             reply_submsg_failed = true;
         }
 
@@ -280,6 +279,7 @@ impl<'a> CwCroncat<'a> {
                 return Ok(response);
             } else {
                 //If Send and reccuring task increment withdrawn funds so contract doesnt get drained
+                let _transferred_bank_tokens = msg.transferred_bank_tokens();
                 if task.contains_send_msg() && task.is_recurring() {
                     //task.funds_withdrawn_recurring.saturating_add(msg..funds[0].amount);
                     self.tasks.save(deps.storage, task_hash, &task)?;
@@ -363,7 +363,7 @@ impl<'a> CwCroncat<'a> {
 mod tests {
     use super::*;
     use cosmwasm_std::{
-        coin, coins, to_binary, Addr, BlockInfo, CosmosMsg, Empty, StakingMsg, WasmMsg,
+        coin, coins, to_binary, Addr, BankMsg, BlockInfo, CosmosMsg, Empty, StakingMsg, WasmMsg,
     };
     use cw_multi_test::{App, AppBuilder, Contract, ContractWrapper, Executor};
     // use cw20::Balance;
@@ -1389,5 +1389,61 @@ mod tests {
         );
         assert!(res.is_ok());
         Ok(())
+    }
+
+    #[test]
+    fn check_bank_msg() {
+        let (mut app, cw_template_contract) = proper_instantiate();
+        let contract_addr = cw_template_contract.addr();
+
+        let to_address = String::from("not_you");
+        let amount = coin(3, "atom");
+        let send = BankMsg::Send {
+            to_address,
+            amount: vec![amount],
+        };
+        let msg: CosmosMsg = send.clone().into();
+        let gas_limit = 150_000;
+        let agent_fee = 5;
+
+        let create_task_msg = ExecuteMsg::CreateTask {
+            task: TaskRequest {
+                interval: Interval::Immediate,
+                boundary: None,
+                stop_on_fail: false,
+                actions: vec![Action {
+                    msg,
+                    gas_limit: Some(gas_limit),
+                }],
+                rules: None,
+            },
+        };
+        // create 1 token off task
+        let amount_for_one_task = gas_limit + agent_fee;
+        // create a task
+        let res = app.execute_contract(
+            Addr::unchecked(ANYONE),
+            contract_addr.clone(),
+            &create_task_msg,
+            &coins(u128::from(amount_for_one_task * 2), "atom"),
+        );
+        assert!(res.is_ok());
+
+        // quick agent register
+        let msg = ExecuteMsg::RegisterAgent {
+            payable_account_id: Some(Addr::unchecked(AGENT1_BENEFICIARY)),
+        };
+        app.execute_contract(Addr::unchecked(AGENT0), contract_addr.clone(), &msg, &[])
+            .unwrap();
+
+        app.update_block(add_little_time);
+
+        app.execute_contract(
+            Addr::unchecked(AGENT0),
+            contract_addr.clone(),
+            &ExecuteMsg::ProxyCall {},
+            &[],
+        )
+        .unwrap();
     }
 }

--- a/contracts/cw-croncat/src/state.rs
+++ b/contracts/cw-croncat/src/state.rs
@@ -166,7 +166,7 @@ mod tests {
     use crate::error::ContractError;
     use crate::helpers::Task;
     use cosmwasm_std::testing::MockStorage;
-    use cosmwasm_std::{coins, BankMsg, CosmosMsg, Order, StdResult};
+    use cosmwasm_std::{coins, BankMsg, CosmosMsg, Order, StdResult, Uint128};
     use cw_croncat_core::types::{Action, BoundaryValidated, Interval};
     use cw_storage_plus::Bound;
 
@@ -181,6 +181,8 @@ mod tests {
         let msg: CosmosMsg = bank.clone().into();
 
         let task = Task {
+            funds_withdrawn_recurring: Uint128::zero(),
+
             owner_id: Addr::unchecked("nobody".to_string()),
             interval: Interval::Immediate,
             boundary: BoundaryValidated {

--- a/contracts/cw-croncat/src/tasks.rs
+++ b/contracts/cw-croncat/src/tasks.rs
@@ -202,7 +202,7 @@ impl<'a> CwCroncat<'a> {
 
         if !item.is_valid_msg(&env.contract.address, &owner_id, &c.owner_id) {
             return Err(ContractError::CustomError {
-                val: "Actions Message Unsupported".to_string(),
+                val: "Actions message unsupported or invalid message data".to_string(),
             });
         }
 

--- a/contracts/cw-croncat/src/tasks.rs
+++ b/contracts/cw-croncat/src/tasks.rs
@@ -3,6 +3,7 @@ use crate::slots::Interval;
 use crate::state::{Config, CwCroncat};
 use cosmwasm_std::{
     coin, Addr, BankMsg, Coin, Deps, DepsMut, Env, MessageInfo, Order, Response, StdResult, SubMsg,
+    Uint128,
 };
 use cw20::Balance;
 use cw_croncat_core::msg::{GetSlotHashesResponse, GetSlotIdsResponse, TaskRequest, TaskResponse};
@@ -189,6 +190,7 @@ impl<'a> CwCroncat<'a> {
         let owner_id = info.sender;
         let boundary = BoundaryValidated::validate_boundary(task.boundary, &task.interval)?;
         let item = Task {
+            funds_withdrawn_recurring: Uint128::zero(),
             owner_id: owner_id.clone(),
             interval: task.interval,
             boundary,
@@ -531,6 +533,7 @@ mod tests {
         let msg: CosmosMsg = bank.clone().into();
 
         let task = Task {
+            funds_withdrawn_recurring: Uint128::zero(),
             owner_id: Addr::unchecked("nobody".to_string()),
             interval: Interval::Immediate,
             boundary: BoundaryValidated {

--- a/contracts/cw-croncat/src/tasks.rs
+++ b/contracts/cw-croncat/src/tasks.rs
@@ -919,7 +919,7 @@ mod tests {
             .unwrap_err();
         assert_eq!(
             ContractError::CustomError {
-                val: "Actions Message Unsupported".to_string()
+                val: "Actions message unsupported or invalid message data".to_string()
             },
             res_err.downcast().unwrap()
         );

--- a/packages/cw-croncat-core/schema/croncat.json
+++ b/packages/cw-croncat-core/schema/croncat.json
@@ -1188,6 +1188,7 @@
       "required": [
         "actions",
         "boundary",
+        "funds_withdrawn_recurring",
         "interval",
         "owner_id",
         "stop_on_fail",
@@ -1203,6 +1204,9 @@
         },
         "boundary": {
           "$ref": "#/definitions/BoundaryValidated"
+        },
+        "funds_withdrawn_recurring": {
+          "$ref": "#/definitions/Uint128"
         },
         "interval": {
           "description": "Scheduling definitions",

--- a/packages/cw-croncat-core/schema/query_msg.json
+++ b/packages/cw-croncat-core/schema/query_msg.json
@@ -849,6 +849,7 @@
       "required": [
         "actions",
         "boundary",
+        "funds_withdrawn_recurring",
         "interval",
         "owner_id",
         "stop_on_fail",
@@ -864,6 +865,9 @@
         },
         "boundary": {
           "$ref": "#/definitions/BoundaryValidated"
+        },
+        "funds_withdrawn_recurring": {
+          "$ref": "#/definitions/Uint128"
         },
         "interval": {
           "description": "Scheduling definitions",

--- a/packages/cw-croncat-core/src/msg.rs
+++ b/packages/cw-croncat-core/src/msg.rs
@@ -241,7 +241,7 @@ pub struct GetSlotIdsResponse {
 
 #[cfg(test)]
 mod tests {
-    use cosmwasm_std::{coin, coins, BankMsg, CosmosMsg, Timestamp};
+    use cosmwasm_std::{coin, coins, BankMsg, CosmosMsg, Timestamp, Uint128};
     use cw20::Cw20CoinVerified;
 
     use crate::types::AgentStatus;
@@ -275,6 +275,7 @@ mod tests {
         .into();
 
         let task = Task {
+            funds_withdrawn_recurring: Uint128::zero(),
             owner_id: Addr::unchecked("nobody".to_string()),
             interval: Interval::Immediate,
             boundary: BoundaryValidated {

--- a/packages/cw-croncat-core/src/msg.rs
+++ b/packages/cw-croncat-core/src/msg.rs
@@ -225,7 +225,7 @@ impl From<Task> for TaskResponse {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 pub struct GetSlotHashesResponse {
     pub block_id: u64,
     pub block_task_hash: Vec<String>,
@@ -233,7 +233,7 @@ pub struct GetSlotHashesResponse {
     pub time_task_hash: Vec<String>,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, JsonSchema)]
 pub struct GetSlotIdsResponse {
     pub time_ids: Vec<u64>,
     pub block_ids: Vec<u64>,

--- a/packages/cw-croncat-core/src/types.rs
+++ b/packages/cw-croncat-core/src/types.rs
@@ -1,5 +1,6 @@
 use cosmwasm_std::{
-    Addr, BankMsg, Binary, Coin, CosmosMsg, Empty, Env, GovMsg, IbcMsg, Timestamp, Uint64, WasmMsg,
+    Addr, BankMsg, Binary, Coin, CosmosMsg, Empty, Env, GovMsg, IbcMsg, Timestamp, Uint128, Uint64,
+    WasmMsg,
 };
 use cron_schedule::Schedule;
 use cw20::{Balance, Cw20CoinVerified};
@@ -170,6 +171,7 @@ pub struct Task {
     /// Scheduling definitions
     pub interval: Interval,
     pub boundary: BoundaryValidated,
+    pub funds_withdrawn_recurring: Uint128,
 
     /// Defines if this task can continue until balance runs out
     pub stop_on_fail: bool,
@@ -213,6 +215,22 @@ impl Task {
             })
     }
 
+    pub fn is_reccuring(&self) -> bool {
+        matches!(&self.interval, Interval::Cron(_) | Interval::Block(_))
+    }
+    pub fn contains_send_msg(&self) -> bool {
+        let result: bool = self.actions.iter().any(|a| -> bool {
+            matches!(
+                &a.msg,
+                CosmosMsg::Bank(BankMsg::Send {
+                    to_address: _,
+                    amount: _,
+                })
+            )
+        });
+        result
+    }
+
     /// Validate the task actions only use the supported messages
     pub fn is_valid_msg(&self, self_addr: &Addr, sender: &Addr, owner_id: &Addr) -> bool {
         // TODO: Chagne to default FALSE, once all messages are covered in tests
@@ -245,19 +263,14 @@ impl Task {
                         || self.total_deposit[0].denom != "ujunox"
                         || amount.is_empty()
                         || amount[0].denom != "ujunox"
-                        || amount[0].amount < self.total_deposit[0].amount
+                        || amount[0].amount > self.total_deposit[0].amount
+                        || (self.is_reccuring()
+                            && self
+                                .funds_withdrawn_recurring
+                                .saturating_add(amount[0].amount)
+                                > self.total_deposit[0].amount)
                     {
                         valid = false
-                    } else {
-                        if let Interval::Cron(crontab) = &self.interval {
-                            
-                        }
-                        // We're good! At least for one execution.
-                        // BIG TODO: we need to check that if this task is recurring, we're checking the validity each time
-                        // because eventually, it will run out of funds and we should never
-                        // drain the Croncat manager contract
-
-                        // implied "valid = true" here.
                     }
                 }
                 CosmosMsg::Bank(BankMsg::Burn { .. }) => {
@@ -463,12 +476,14 @@ impl Intervals for Interval {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use cosmwasm_std::{IbcTimeout, VoteOption};
+    use cosmwasm_std::{IbcTimeout, Uint128, VoteOption};
     use hex::ToHex;
 
     #[test]
     fn is_valid_msg_once_block_based() {
         let task = Task {
+            funds_withdrawn_recurring: Uint128::zero(),
+
             owner_id: Addr::unchecked("bob"),
             interval: Interval::Once,
             boundary: BoundaryValidated {
@@ -500,6 +515,8 @@ mod tests {
     #[test]
     fn is_valid_msg_once_time_based() {
         let task = Task {
+            funds_withdrawn_recurring: Uint128::zero(),
+
             owner_id: Addr::unchecked("bob"),
             interval: Interval::Once,
             boundary: BoundaryValidated {
@@ -531,6 +548,8 @@ mod tests {
     #[test]
     fn is_valid_msg_recurring() {
         let task = Task {
+            funds_withdrawn_recurring: Uint128::zero(),
+
             owner_id: Addr::unchecked("bob"),
             interval: Interval::Block(10),
             boundary: BoundaryValidated {
@@ -563,6 +582,8 @@ mod tests {
     fn is_valid_msg_wrong_account() {
         // Cannot create a task to execute on the cron manager when not the owner
         let task = Task {
+            funds_withdrawn_recurring: Uint128::zero(),
+
             owner_id: Addr::unchecked("alice"),
             interval: Interval::Block(5),
             boundary: BoundaryValidated {
@@ -595,6 +616,8 @@ mod tests {
     fn is_valid_msg_vote() {
         // A task with CosmosMsg::Gov Vote should return false
         let task = Task {
+            funds_withdrawn_recurring: Uint128::zero(),
+
             owner_id: Addr::unchecked("bob"),
             interval: Interval::Block(5),
             boundary: BoundaryValidated {
@@ -626,6 +649,8 @@ mod tests {
     fn is_valid_msg_transfer() {
         // A task with CosmosMsg::Ibc Transfer should return false
         let task = Task {
+            funds_withdrawn_recurring: Uint128::zero(),
+
             owner_id: Addr::unchecked("bob"),
             interval: Interval::Block(5),
             boundary: BoundaryValidated {
@@ -659,6 +684,8 @@ mod tests {
     fn is_valid_msg_burn() {
         // A task with CosmosMsg::Bank Burn should return false
         let task = Task {
+            funds_withdrawn_recurring: Uint128::zero(),
+
             owner_id: Addr::unchecked("bob"),
             interval: Interval::Block(5),
             boundary: BoundaryValidated {
@@ -689,6 +716,8 @@ mod tests {
     fn is_valid_msg_send() {
         // A task with CosmosMsg::Bank Send should return false
         let task = Task {
+            funds_withdrawn_recurring: Uint128::zero(),
+
             owner_id: Addr::unchecked("bob"),
             interval: Interval::Block(5),
             boundary: BoundaryValidated {
@@ -884,6 +913,7 @@ mod tests {
     #[test]
     fn hashing() {
         let task = Task {
+            funds_withdrawn_recurring: Uint128::zero(),
             owner_id: Addr::unchecked("bob"),
             interval: Interval::Block(5),
             boundary: BoundaryValidated {

--- a/packages/cw-croncat-core/src/types.rs
+++ b/packages/cw-croncat-core/src/types.rs
@@ -249,6 +249,9 @@ impl Task {
                     {
                         valid = false
                     } else {
+                        if let Interval::Cron(crontab) = &self.interval {
+                            
+                        }
                         // We're good! At least for one execution.
                         // BIG TODO: we need to check that if this task is recurring, we're checking the validity each time
                         // because eventually, it will run out of funds and we should never

--- a/packages/cw-croncat-core/src/types.rs
+++ b/packages/cw-croncat-core/src/types.rs
@@ -215,7 +215,7 @@ impl Task {
             })
     }
 
-    pub fn is_reccuring(&self) -> bool {
+    pub fn is_recurring(&self) -> bool {
         matches!(&self.interval, Interval::Cron(_) | Interval::Block(_))
     }
     pub fn contains_send_msg(&self) -> bool {
@@ -264,7 +264,7 @@ impl Task {
                         || amount.is_empty()
                         || amount[0].denom != "ujunox"
                         || amount[0].amount > self.total_deposit[0].amount
-                        || (self.is_reccuring()
+                        || (self.is_recurring()
                             && self
                                 .funds_withdrawn_recurring
                                 .saturating_add(amount[0].amount)

--- a/packages/cw-croncat-core/src/types.rs
+++ b/packages/cw-croncat-core/src/types.rs
@@ -260,9 +260,9 @@ impl Task {
                     // which is however much was passed in, like 1000000ujunox below:
                     // junod tx wasm execute … … --amount 1000000ujunox
                     if self.total_deposit.is_empty()
-                        || self.total_deposit[0].denom != "ujunox"
+                        || self.total_deposit[0].denom != "atom" // Changed this to atom just for tests, in the end we should look for every `amount` in the `total_deposit`
                         || amount.is_empty()
-                        || amount[0].denom != "ujunox"
+                        || amount[0].denom != "atom"
                         || amount[0].amount > self.total_deposit[0].amount
                         || (self.is_recurring()
                             && self

--- a/packages/cw-croncat-core/src/types.rs
+++ b/packages/cw-croncat-core/src/types.rs
@@ -232,41 +232,29 @@ impl Task {
                     }
                 }
                 // TODO: Allow send, as long as coverage of assets is correctly handled
-                CosmosMsg::Bank(BankMsg::Send { to_address, amount }) => {
+                CosmosMsg::Bank(BankMsg::Send {
+                    to_address: _,
+                    amount,
+                }) => {
                     // Restrict bank msg for time being, so contract doesnt get drained, however could allow an escrow type setup
                     // Do something silly to keep it simple. Ensure they only sent one kind of native token and it's testnet Juno
                     // Remember total_deposit is set in tasks.rs when a task is created, and assigned to info.funds
                     // which is however much was passed in, like 1000000ujunox below:
                     // junod tx wasm execute … … --amount 1000000ujunox
-                    if self.total_deposit.is_empty() {
+                    if self.total_deposit.is_empty()
+                        || self.total_deposit[0].denom != "ujunox"
+                        || amount.is_empty()
+                        || amount[0].denom != "ujunox"
+                        || amount[0].amount < self.total_deposit[0].amount
+                    {
                         valid = false
                     } else {
-                        if self.total_deposit[0].denom != "ujunox" {
-                            valid = false;
-                        } else {
-                            // They've attached some testnet Juno, but make sure it's at least as much as is being paid out
-                            // Remember the "amount" is how much the Bank Message that we're passing in is saying to pay
-                            // So it's possible someone is trying to have Croncat do a Bank message
-                            // for more than their attached deposit. Let's check
-                            if amount.is_empty() || amount[0].denom != "ujunox" {
-                                // They sent more than one native token
-                                // or they tried to attach something different than testnet juno
-                                valid = false
-                            } else {
-                                // So far so good, now let's ensure they attached enough
-                                if amount[0].amount < self.total_deposit[0].amount {
-                                    // These jokers are trying to pay out more than they gave us!
-                                    valid = false
-                                } else {
-                                    // We're good! At least for one execution.
-                                    // BIG TODO: we need to check that if this task is recurring, we're checking the validity each time
-                                    // because eventually, it will run out of funds and we should never
-                                    // drain the Croncat manager contract
+                        // We're good! At least for one execution.
+                        // BIG TODO: we need to check that if this task is recurring, we're checking the validity each time
+                        // because eventually, it will run out of funds and we should never
+                        // drain the Croncat manager contract
 
-                                    // implied "valid = true" here.
-                                }
-                            }
-                        }
+                        // implied "valid = true" here.
                     }
                 }
                 CosmosMsg::Bank(BankMsg::Burn { .. }) => {

--- a/types/contract/CwCroncatContract.ts
+++ b/types/contract/CwCroncatContract.ts
@@ -291,6 +291,7 @@ export interface Rule {
 export interface Task {
   actions: ActionForEmpty[];
   boundary: BoundaryValidated;
+  funds_withdrawn_recurring: Uint128;
   interval: Interval;
   owner_id: Addr;
   rules?: Rule[] | null;


### PR DESCRIPTION
We need to make sure users can send a `Bank` message, since this is the primary case we're trying to solve for DAO DAO.

I've done some very basic work here to do some sanity checks on what the user (the one creating the task) is trying to accomplish, and make sure they aren't doing any funny business.

Note that this will only work for Croncat tasks that are "immediate" instead of recurring ones, because it does not implement the check to see if the user attached enough for multiple payments.

Also, obviously note that this is not production code since we're hardcoding in the JUNO testnet token denomination, which is `ujunox`. Obviously that part will not make it into production, but I really want us to see a Bank message working on testnet. It SHOULD WORK, but if it doens't work, we should stop what we're doing and focus on why a simple Bank message isn't working, and prioritize that. If it DOES WORK then we can continue making this production ready, remove the hardcoding, allow for recurring tasks, etc.