### PR TITLE
Supporting multiaction for tasks and balance fixes

### DIFF
--- a/contracts/cw-croncat/src/agent.rs
+++ b/contracts/cw-croncat/src/agent.rs
@@ -21,7 +21,7 @@ impl<'a> CwCroncat<'a> {
         env: Env,
         account_id: Addr,
     ) -> StdResult<Option<AgentResponse>> {
-        let agent = self.agents.may_load(deps.storage, account_id.clone())?;
+        let agent = self.agents.may_load(deps.storage, &account_id)?;
         if agent.is_none() {
             return Ok(None);
         }
@@ -191,7 +191,7 @@ impl<'a> CwCroncat<'a> {
 
         self.agents.update(
             deps.storage,
-            account,
+            &account,
             |a: Option<Agent>| -> Result<_, ContractError> {
                 match a {
                     // make sure that account isn't already added
@@ -235,7 +235,7 @@ impl<'a> CwCroncat<'a> {
 
         self.agents.update(
             deps.storage,
-            info.sender,
+            &info.sender,
             |a: Option<Agent>| -> Result<_, ContractError> {
                 match a {
                     Some(agent) => {
@@ -257,7 +257,7 @@ impl<'a> CwCroncat<'a> {
         storage: &mut dyn Storage,
         info: MessageInfo,
     ) -> Result<Vec<SubMsg>, ContractError> {
-        let a = self.agents.may_load(storage, info.sender)?;
+        let a = self.agents.may_load(storage, &info.sender)?;
         if a.is_none() {
             return Err(ContractError::AgentNotRegistered {});
         }
@@ -370,7 +370,7 @@ impl<'a> CwCroncat<'a> {
         // NOTE: Since this also checks if agent exists, safe to not have redundant logic
         let messages = self.withdraw_balances(deps.storage, info.clone())?;
         let agent_id = info.sender;
-        self.agents.remove(deps.storage, agent_id.clone());
+        self.agents.remove(deps.storage, &agent_id);
 
         // Remove from the list of active agents if the agent in this list
         let mut active_agents: Vec<Addr> = self

--- a/contracts/cw-croncat/src/balancer.rs
+++ b/contracts/cw-croncat/src/balancer.rs
@@ -77,9 +77,9 @@ impl RoundRobinBalancer {
         let mut vec: Vec<(SlotType, u32, u32)> = Vec::new();
         for p in indices.iter() {
             let val = if p.1 > agent_index {
-                (p.0.clone(), p.1 - 1, p.2)
+                (p.0, p.1 - 1, p.2)
             } else {
-                (p.0.clone(), p.1, p.2)
+                (p.0, p.1, p.2)
             };
             vec.push(val);
         }

--- a/contracts/cw-croncat/src/helpers.rs
+++ b/contracts/cw-croncat/src/helpers.rs
@@ -221,7 +221,7 @@ impl<'a> CwCroncat<'a> {
         let mut config = self.config.load(storage)?;
         let action_idx = queue_item.action_idx;
         let action = &task.actions[action_idx as usize];
-        // slicing gas costs from task even if it failed 
+        // slicing gas costs from task even if it failed
         // TODO: it's movable to the `proxy_call`
         let gas = Coin {
             denom: config.native_denom,

--- a/contracts/cw-croncat/src/helpers.rs
+++ b/contracts/cw-croncat/src/helpers.rs
@@ -44,7 +44,7 @@ pub(crate) fn send_tokens(
     to: &Addr,
     balance: &GenericBalance,
 ) -> StdResult<(Vec<SubMsg>, GenericBalance)> {
-    let native_balance = &balance.native.clone();
+    let native_balance = &balance.native;
     let mut coins: GenericBalance = GenericBalance::default();
     let mut msgs: Vec<SubMsg> = if native_balance.is_empty() {
         vec![]

--- a/contracts/cw-croncat/src/helpers.rs
+++ b/contracts/cw-croncat/src/helpers.rs
@@ -204,6 +204,7 @@ impl<'a> CwCroncat<'a> {
         }
     }
 
+    // Change balances of task and contract if action did transaction that went through
     pub fn task_after_action(
         &self,
         storage: &mut dyn Storage,

--- a/contracts/cw-croncat/src/helpers.rs
+++ b/contracts/cw-croncat/src/helpers.rs
@@ -44,12 +44,12 @@ pub(crate) fn send_tokens(
     to: &Addr,
     balance: &GenericBalance,
 ) -> StdResult<(Vec<SubMsg>, GenericBalance)> {
-    let native_balance = &balance.native;
+    let native_balance = &balance.native.clone();
     let mut coins: GenericBalance = GenericBalance::default();
     let mut msgs: Vec<SubMsg> = if native_balance.is_empty() {
         vec![]
     } else {
-        coins.native = balance.native.clone();
+        coins.native = native_balance.to_vec();
         vec![SubMsg::new(BankMsg::Send {
             to_address: to.into(),
             amount: native_balance.to_vec(),
@@ -72,7 +72,7 @@ pub(crate) fn send_tokens(
             Ok(exec)
         })
         .collect();
-    coins.cw20 = balance.cw20.clone();
+    coins.cw20 = cw20_balance.to_vec();
     msgs.append(&mut cw20_msgs?);
     Ok((msgs, coins))
 }

--- a/contracts/cw-croncat/src/helpers.rs
+++ b/contracts/cw-croncat/src/helpers.rs
@@ -221,7 +221,8 @@ impl<'a> CwCroncat<'a> {
         let mut config = self.config.load(storage)?;
         let action_idx = queue_item.action_idx;
         let action = &task.actions[action_idx as usize];
-        // slicing gas costs from task even if it failed
+        // slicing gas costs from task even if it failed 
+        // TODO: it's movable to the `proxy_call`
         let gas = Coin {
             denom: config.native_denom,
             amount: Uint128::from(action.gas_limit.unwrap_or(config.gas_base_fee)),

--- a/contracts/cw-croncat/src/manager.rs
+++ b/contracts/cw-croncat/src/manager.rs
@@ -4,9 +4,8 @@ use crate::helpers::ReplyMsgParser;
 use crate::state::{Config, CwCroncat, QueueItem, TaskInfo};
 use cosmwasm_std::{
     Addr, DepsMut, Empty, Env, MessageInfo, Reply, Response, StdResult, Storage, SubMsg,
-    SubMsgResult,
 };
-use cw_croncat_core::traits::Intervals;
+use cw_croncat_core::traits::{BalancesOperations, Intervals, ResultFailed};
 use cw_croncat_core::types::{Agent, SlotType};
 
 impl<'a> CwCroncat<'a> {
@@ -108,7 +107,7 @@ impl<'a> CwCroncat<'a> {
             .unwrap()
             .unwrap();
         //Balanacer gives not task to this agent, return error
-        let has_tasks = balancer_result.has_any_slot_tasks(slot_type.clone());
+        let has_tasks = balancer_result.has_any_slot_tasks(slot_type);
         if !has_tasks {
             return Err(ContractError::NoTaskFound {});
         }
@@ -225,11 +224,12 @@ impl<'a> CwCroncat<'a> {
         self.rq_push(
             deps.storage,
             QueueItem {
-                prev_idx: None,
+                action_idx: 0,
                 task_hash: Some(hash),
                 contract_addr: Some(self_addr),
-                task_is_extra: Some(balancer_result.has_any_slot_extra_tasks(slot_type.clone())),
+                task_is_extra: Some(balancer_result.has_any_slot_extra_tasks(slot_type)),
                 agent_id: Some(info.sender.clone()),
+                failed: false,
             },
         )?;
 
@@ -284,107 +284,117 @@ impl<'a> CwCroncat<'a> {
         deps: DepsMut,
         env: Env,
         msg: Reply,
-        task_hash: Vec<u8>,
-        task_is_extra: bool,
-        agent_id: Addr,
+        mut queue_item: QueueItem,
     ) -> Result<Response, ContractError> {
-        let mut response = Response::new().add_attribute("method", "proxy_callback");
+        let task_hash = queue_item.task_hash.clone().unwrap();
+        let action_idx = queue_item.action_idx;
 
         // check if reply had failure
-        let mut reply_submsg_failed = false;
-        if let SubMsgResult::Ok(response) = &msg.result {
-            for e in &response.events {
-                for a in &e.attributes {
-                    if e.ty == "reply" && a.key == "mode" && a.value == "handle_failure" {
-                        reply_submsg_failed = true;
-                    }
-                }
+        let reply_submsg_failed = msg.result.failed();
+        let task = {
+            let mut task = self
+                .tasks
+                .may_load(deps.storage, task_hash.clone())?
+                .ok_or(ContractError::NoTaskFound {})?;
+
+            // Check what task it is and then subtract if it did sent any tokens
+            if !reply_submsg_failed {
+                let action = &task.actions[action_idx as usize];
+                if let Some(sent) = action.bank_sent() {
+                    task.total_deposit.checked_sub_coins(sent)?;
+                } else if let Some(sent) = action.cw20_sent(deps.api) {
+                    task.total_cw20_deposit
+                        .checked_sub_coins(std::iter::once(&sent))?;
+                };
             }
-            //let agentid=msg.result.unwrap().events.get(index)
-            //self.balancer.on_task_completed(task_hash, agentid);
+            task
+        };
+        if action_idx + 1 == task.actions.len() as u64 {
+            // Last action
+            self.rq_remove(deps.storage, msg.id)
         } else {
-            reply_submsg_failed = true;
+            // not over yet
+            queue_item.failed = if reply_submsg_failed {
+                reply_submsg_failed
+            } else {
+                queue_item.failed
+            };
+            self.rq_update_rq_item(deps.storage, msg.id, queue_item.failed)?;
+            return Ok(Response::new()
+                .add_attribute("method", "proxy_callback")
+                .add_attribute("action_idx", format!("{}", action_idx)));
+        }
+        let task_hash_str = task.to_hash();
+        // TODO: How can we compute gas & fees paid on this txn?
+        // let out_of_funds = call_total_balance > task.total_deposit;
+
+        // if non-recurring, exit
+        if task.stop_on_fail && queue_item.failed {
+            // Process task exit, if no future task can execute
+            let rt = self.remove_task(deps.storage, task_hash_str);
+            let resp = rt.unwrap_or_default();
+            return Ok(Response::new()
+                .add_attribute("method", "proxy_callback")
+                .add_attributes(resp.attributes)
+                .add_submessages(resp.messages)
+                .add_events(resp.events));
         }
 
         // reschedule next!
-        if let Some(task) = self.tasks.may_load(deps.storage, task_hash.clone())? {
-            let task_hash_str = task.to_hash();
-            // TODO: How can we compute gas & fees paid on this txn?
-            // let out_of_funds = call_total_balance > task.total_deposit;
+        // Parse interval into a future timestamp, then convert to a slot
+        let (next_id, slot_kind) = task.interval.next(env.clone(), task.boundary);
 
-            // if non-recurring, exit
-            if task.stop_on_fail && reply_submsg_failed {
-                // Process task exit, if no future task can execute
-                let rt = self.remove_task(deps.storage, task_hash_str);
-                if let Ok(..) = rt {
-                    let resp = rt.unwrap();
-                    response = response
-                        .add_attributes(resp.attributes)
-                        .add_submessages(resp.messages)
-                        .add_events(resp.events);
+        let task_info = TaskInfo {
+            task: Some(task.clone()),
+            task_hash,
+            task_is_extra: queue_item.task_is_extra,
+            slot_kind,
+            agent_id: queue_item.agent_id,
+        };
+        // If the next interval comes back 0, then this task should not schedule again
+        if next_id == 0 {
+            let rt = self.remove_task(deps.storage, task_hash_str.clone());
+            let resp = rt.unwrap_or_default();
+            //Task has been removed, complete and rebalance internal balancer
+            self.complete_agent_task(deps.storage, env, msg, task_info)
+                .unwrap();
+            return Ok(Response::new()
+                .add_attribute("method", "proxy_callback")
+                .add_attribute("ended_task", task_hash_str)
+                .add_attributes(resp.attributes)
+                .add_submessages(resp.messages)
+                .add_events(resp.events));
+        }
+        // Get previous task hashes in slot, add as needed
+        let update_vec_data = |d: Option<Vec<Vec<u8>>>| -> StdResult<Vec<Vec<u8>>> {
+            match d {
+                // has some data, simply push new hash
+                Some(data) => {
+                    let mut s = data;
+                    s.push(task.to_hash_vec());
+                    Ok(s)
                 }
-                return Ok(response);
+                // No data, push new vec & hash
+                None => Ok(vec![task.to_hash_vec()]),
             }
+        };
 
-            // Parse interval into a future timestamp, then convert to a slot
-            let (next_id, slot_kind) = task.interval.next(env.clone(), task.boundary);
-            let task_info = TaskInfo {
-                task: Some(task.clone()),
-                task_hash,
-                task_is_extra: Some(task_is_extra),
-                slot_kind: slot_kind.clone(),
-                agent_id: Some(agent_id),
-            };
-            // If the next interval comes back 0, then this task should not schedule again
-            if next_id == 0 {
-                let rt = self.remove_task(deps.storage, task_hash_str.clone());
-                if let Ok(..) = rt {
-                    let resp = rt.unwrap();
-                    response = response
-                        .add_attributes(resp.attributes)
-                        .add_submessages(resp.messages)
-                        .add_events(resp.events);
-                }
-                response = response.add_attribute("ended_task", task_hash_str);
-                //Task has been removed, complete and rebalance internal balancer
-                self.complete_agent_task(deps.storage, env, msg, task_info)
-                    .unwrap();
-                return Ok(response);
+        // Based on slot kind, put into block or cron slots
+        match slot_kind {
+            SlotType::Block => {
+                self.block_slots
+                    .update(deps.storage, next_id, update_vec_data)?;
             }
-
-            response = response.add_attribute("slot_id", next_id.to_string());
-            response = response.add_attribute("slot_kind", format!("{:?}", slot_kind));
-
-            // Get previous task hashes in slot, add as needed
-            let update_vec_data = |d: Option<Vec<Vec<u8>>>| -> StdResult<Vec<Vec<u8>>> {
-                match d {
-                    // has some data, simply push new hash
-                    Some(data) => {
-                        let mut s = data;
-                        s.push(task.to_hash_vec());
-                        Ok(s)
-                    }
-                    // No data, push new vec & hash
-                    None => Ok(vec![task.to_hash_vec()]),
-                }
-            };
-
-            // Based on slot kind, put into block or cron slots
-            match slot_kind {
-                SlotType::Block => {
-                    self.block_slots
-                        .update(deps.storage, next_id, update_vec_data)?;
-                }
-                SlotType::Cron => {
-                    self.time_slots
-                        .update(deps.storage, next_id, update_vec_data)?;
-                }
+            SlotType::Cron => {
+                self.time_slots
+                    .update(deps.storage, next_id, update_vec_data)?;
             }
-        } else {
-            return Err(ContractError::NoTaskFound {});
         }
 
-        Ok(response)
+        Ok(Response::new()
+            .add_attribute("method", "proxy_callback")
+            .add_attribute("slot_id", next_id.to_string())
+            .add_attribute("slot_kind", format!("{:?}", slot_kind)))
     }
 
     /// Internal management of agent reward
@@ -428,6 +438,7 @@ impl<'a> CwCroncat<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::contract::GAS_BASE_FEE_JUNO;
     use cosmwasm_std::{
         coin, coins, to_binary, Addr, BankMsg, BlockInfo, CosmosMsg, Empty, StakingMsg, WasmMsg,
     };
@@ -491,7 +502,8 @@ mod tests {
                 cw_template_id,
                 owner_addr,
                 &msg,
-                &coins(2_000_000, NATIVE_DENOM),
+                // Contract balance is that low for testing doublespend
+                &coins(1, NATIVE_DENOM),
                 "Manager",
                 None,
             )
@@ -923,6 +935,7 @@ mod tests {
             ("slot_kind", "Block"),
             ("task_hash", task_id_str.as_str().clone()),
         ];
+        println!("events: {:?}", res.events);
 
         // check all attributes are covered in response, and match the expected values
         for (k, v) in attributes.iter() {
@@ -953,6 +966,7 @@ mod tests {
             if let Some(_key) = attr_key {
                 if let Some(value) = attr_value {
                     if v.to_string() != value {
+                        println!("v: {v}, value: {value}");
                         has_required_attributes = false;
                     }
                 } else {
@@ -1583,67 +1597,74 @@ mod tests {
         Ok(())
     }
 
-    // TODO: !!!!!!! WE REALLY MUST SUPPORT MULTI-ACTION !!!!!!!!!!!!
-    // #[test]
-    // fn check_multi_action() {
-    //     let (mut app, cw_template_contract) = proper_instantiate();
-    //     let contract_addr = cw_template_contract.addr();
+    #[test]
+    fn check_multi_action() {
+        let (mut app, cw_template_contract) = proper_instantiate();
+        let contract_addr = cw_template_contract.addr();
 
-    //     let validator = String::from("you");
-    //     let amount = coin(3, "atom");
-    //     let stake = StakingMsg::Delegate { validator, amount };
-    //     let msg: CosmosMsg = stake.clone().into();
-    //     let gas_limit = GAS_BASE_FEE_JUNO;
-    //     let agent_fee = 5;
+        let addr1 = String::from("addr1");
+        let addr2 = String::from("addr2");
+        let amount = coins(3, "atom");
+        let send = BankMsg::Send {
+            to_address: addr1,
+            amount,
+        };
+        let msg1: CosmosMsg = send.into();
+        let amount = coins(4, "atom");
+        let send = BankMsg::Send {
+            to_address: addr2,
+            amount,
+        };
+        let msg2: CosmosMsg = send.into();
 
-    //     let create_task_msg = ExecuteMsg::CreateTask {
-    //         task: TaskRequest {
-    //             interval: Interval::Immediate,
-    //             boundary: None,
-    //             stop_on_fail: false,
-    //             actions: vec![
-    //                 Action {
-    //                     msg: msg.clone(),
-    //                     gas_limit: None,
-    //                 },
-    //                 // Action {
-    //                 //     msg,
-    //                 //     gas_limit: None,
-    //                 // },
-    //             ],
-    //             rules: None,
-    //             cw20_coins: vec![],
-    //         },
-    //     };
-    //     // create 1 token off task
-    //     let amount_for_one_task = (gas_limit * 2) + agent_fee;
+        let create_task_msg = ExecuteMsg::CreateTask {
+            task: TaskRequest {
+                interval: Interval::Once,
+                boundary: None,
+                stop_on_fail: false,
+                actions: vec![
+                    Action {
+                        msg: msg1,
+                        gas_limit: None,
+                    },
+                    Action {
+                        msg: msg2,
+                        gas_limit: None,
+                    },
+                ],
+                rules: None,
+                cw20_coins: vec![],
+            },
+        };
+        let gas_limit = GAS_BASE_FEE_JUNO;
+        let agent_fee = 5; // TODO: might change
+        let amount_for_one_task = (gas_limit * 2) + agent_fee + 3 + 4; // + 3 + 4 atoms sent
 
-    //     // create a task
-    //     let res = app.execute_contract(
-    //         Addr::unchecked(ADMIN),
-    //         contract_addr.clone(),
-    //         &create_task_msg,
-    //         &coins(u128::from(amount_for_one_task * 2), "atom"),
-    //     );
-    //     assert!(res.is_ok());
+        // create a task
+        app.execute_contract(
+            Addr::unchecked(ADMIN),
+            contract_addr.clone(),
+            &create_task_msg,
+            &coins(u128::from(amount_for_one_task), "atom"),
+        )
+        .unwrap();
 
-    //     // quick agent register
-    //     let msg = ExecuteMsg::RegisterAgent {
-    //         payable_account_id: Some(Addr::unchecked(AGENT1_BENEFICIARY)),
-    //     };
-    //     app.execute_contract(Addr::unchecked(AGENT0), contract_addr.clone(), &msg, &[])
-    //         .unwrap();
+        // quick agent register
+        let msg = ExecuteMsg::RegisterAgent {
+            payable_account_id: Some(Addr::unchecked(AGENT1_BENEFICIARY)),
+        };
+        app.execute_contract(Addr::unchecked(AGENT0), contract_addr.clone(), &msg, &[])
+            .unwrap();
 
-    //     app.update_block(add_little_time);
+        app.update_block(add_little_time);
 
-    //     let proxy_call_msg = ExecuteMsg::ProxyCall {};
-    //     let res = app.execute_contract(
-    //         Addr::unchecked(AGENT0),
-    //         contract_addr.clone(),
-    //         &proxy_call_msg,
-    //         &vec![],
-    //     );
-    //     println!("{res:?}");
-    //     assert!(res.is_ok());
-    // }
+        let proxy_call_msg = ExecuteMsg::ProxyCall {};
+        let res = app.execute_contract(
+            Addr::unchecked(AGENT0),
+            contract_addr.clone(),
+            &proxy_call_msg,
+            &vec![],
+        );
+        assert!(res.is_ok());
+    }
 }

--- a/contracts/cw-croncat/src/manager.rs
+++ b/contracts/cw-croncat/src/manager.rs
@@ -1756,7 +1756,7 @@ mod tests {
             admin_balance_before_proxy_call.amount + Uint128::from(extra)
         );
 
-        // checking balances of recipients 
+        // checking balances of recipients
         let balance_addr1 = app.wrap().query_balance("addr1", "atom").unwrap();
         assert_eq!(
             balance_addr1,
@@ -1776,5 +1776,34 @@ mod tests {
         );
 
         // checking balance of agent and contract after withdrawal
+        let beneficary_balance_before_withdraw = app
+            .wrap()
+            .query_balance(AGENT1_BENEFICIARY, "atom")
+            .unwrap();
+        let contract_balance_before_withdraw =
+            app.wrap().query_balance(&contract_addr, "atom").unwrap();
+        let withdraw_msg = ExecuteMsg::WithdrawReward {};
+        app.execute_contract(
+            Addr::unchecked(AGENT0),
+            contract_addr.clone(),
+            &withdraw_msg,
+            &[],
+        )
+        .unwrap();
+        let beneficary_balance_after_withdraw = app
+            .wrap()
+            .query_balance(AGENT1_BENEFICIARY, "atom")
+            .unwrap();
+        let contract_balance_after_withdraw =
+            app.wrap().query_balance(&contract_addr, "atom").unwrap();
+        let expected_transfer_amount = Uint128::from((gas_limit * 2) + agent_fee);
+        assert_eq!(
+            beneficary_balance_after_withdraw.amount,
+            beneficary_balance_before_withdraw.amount + expected_transfer_amount
+        );
+        assert_eq!(
+            contract_balance_after_withdraw.amount,
+            contract_balance_before_withdraw.amount - expected_transfer_amount
+        )
     }
 }

--- a/contracts/cw-croncat/src/manager.rs
+++ b/contracts/cw-croncat/src/manager.rs
@@ -309,16 +309,16 @@ impl<'a> CwCroncat<'a> {
             }
             task
         };
+        queue_item.failed = if reply_submsg_failed {
+            reply_submsg_failed
+        } else {
+            queue_item.failed
+        };
         if action_idx + 1 == task.actions.len() as u64 {
             // Last action
             self.rq_remove(deps.storage, msg.id)
         } else {
             // not over yet
-            queue_item.failed = if reply_submsg_failed {
-                reply_submsg_failed
-            } else {
-                queue_item.failed
-            };
             self.rq_update_rq_item(deps.storage, msg.id, queue_item.failed)?;
             return Ok(Response::new()
                 .add_attribute("method", "proxy_callback")

--- a/contracts/cw-croncat/src/owner.rs
+++ b/contracts/cw-croncat/src/owner.rs
@@ -1,5 +1,3 @@
-use std::slice;
-
 use crate::error::ContractError;
 use crate::helpers::has_cw_coins;
 use crate::state::{Config, CwCroncat};
@@ -11,6 +9,7 @@ use cw20::{Balance, Cw20ExecuteMsg};
 use cw_croncat_core::msg::{
     ExecuteMsg, GetBalancesResponse, GetConfigResponse, GetWalletBalancesResponse,
 };
+use cw_croncat_core::traits::FindAndMutate;
 
 impl<'a> CwCroncat<'a> {
     pub(crate) fn query_config(&self, deps: Deps) -> StdResult<GetConfigResponse> {
@@ -224,9 +223,7 @@ impl<'a> CwCroncat<'a> {
                         }
 
                         // Update internal registry balance
-                        config
-                            .available_balance
-                            .checked_sub_cw20(slice::from_ref(&bal))?;
+                        config.available_balance.cw20.find_checked_sub(&bal)?;
 
                         let msg = Cw20ExecuteMsg::Transfer {
                             recipient: account_id.clone().into(),

--- a/contracts/cw-croncat/src/receiver.rs
+++ b/contracts/cw-croncat/src/receiver.rs
@@ -190,7 +190,7 @@ mod test {
         .into();
         let create_task_msg = ExecuteMsg::CreateTask {
             task: TaskRequest {
-                interval: Interval::Immediate,
+                interval: Interval::Once,
                 boundary: None,
                 stop_on_fail: false,
                 actions: vec![Action {
@@ -316,7 +316,7 @@ mod test {
         .into();
         let create_task_msg = ExecuteMsg::CreateTask {
             task: TaskRequest {
-                interval: Interval::Immediate,
+                interval: Interval::Once,
                 boundary: None,
                 stop_on_fail: false,
                 actions: vec![Action {

--- a/contracts/cw-croncat/src/slots.rs
+++ b/contracts/cw-croncat/src/slots.rs
@@ -119,7 +119,7 @@ mod tests {
         for (interval, boundary, outcome_block, outcome_slot_kind) in cases.iter() {
             let env = mock_env();
             // CHECK IT!
-            let (next_id, slot_kind) = interval.next(env, boundary.clone());
+            let (next_id, slot_kind) = interval.next(&env, boundary.clone());
             println!("next_id {:?}, slot_kind {:?}", next_id, slot_kind);
             assert_eq!(outcome_block, &next_id);
             assert_eq!(outcome_slot_kind, &slot_kind);
@@ -151,7 +151,7 @@ mod tests {
         for (interval, boundary, outcome_block, outcome_slot_kind) in cases.iter() {
             let env = mock_env();
             // CHECK IT!
-            let (next_id, slot_kind) = interval.next(env, boundary.clone());
+            let (next_id, slot_kind) = interval.next(&env, boundary.clone());
             assert_eq!(outcome_block, &next_id);
             assert_eq!(outcome_slot_kind, &slot_kind);
         }

--- a/contracts/cw-croncat/src/state.rs
+++ b/contracts/cw-croncat/src/state.rs
@@ -93,13 +93,13 @@ pub fn token_owner_idx(d: &Task) -> Addr {
 pub struct CwCroncat<'a> {
     pub config: Item<'a, Config>,
 
-    pub agents: Map<'a, Addr, Agent>,
+    pub agents: Map<'a, &'a Addr, Agent>,
     // TODO: Assess if diff store structure is needed for these:
     pub agent_active_queue: Item<'a, Vec<Addr>>,
     pub agent_pending_queue: Item<'a, Vec<Addr>>,
 
     // REF: https://github.com/CosmWasm/cw-plus/tree/main/packages/storage-plus#indexedmap
-    pub tasks: IndexedMap<'a, Vec<u8>, Task, TaskIndexes<'a>>,
+    pub tasks: IndexedMap<'a, &'a [u8], Task, TaskIndexes<'a>>,
     pub task_total: Item<'a, u64>,
 
     /// Timestamps can be grouped into slot buckets (1-60 second buckets) for easier agent handling
@@ -245,7 +245,7 @@ mod tests {
         // create a task
         let res = store
             .tasks
-            .update(&mut storage, task.to_hash_vec(), |old| match old {
+            .update(&mut storage, &task.to_hash_vec(), |old| match old {
                 Some(_) => Err(ContractError::CustomError {
                     val: "Already exists".to_string(),
                 }),
@@ -275,7 +275,7 @@ mod tests {
         assert_eq!(all_task_ids.unwrap(), vec![task_id_str.clone()]);
 
         // get single task
-        let get_task = store.tasks.load(&mut storage, task_id)?;
+        let get_task = store.tasks.load(&mut storage, &task_id)?;
         assert_eq!(get_task, task);
 
         Ok(())

--- a/contracts/cw-croncat/src/state.rs
+++ b/contracts/cw-croncat/src/state.rs
@@ -190,7 +190,11 @@ impl<'a> CwCroncat<'a> {
     ) -> Result<QueueItem, ContractError> {
         self.reply_queue.update(storage, idx, |rq| {
             let mut rq = rq.ok_or(ContractError::UnknownReplyID {})?;
-            rq.failed = failed;
+            // if first fails it means whole thing failed
+            // for cases where we stop task on failure
+            if !rq.failed {
+                rq.failed = failed;
+            }
             rq.action_idx += 1;
             Ok(rq)
         })

--- a/contracts/cw-croncat/src/state.rs
+++ b/contracts/cw-croncat/src/state.rs
@@ -231,8 +231,8 @@ mod tests {
                 end: None,
             },
             stop_on_fail: false,
-            total_deposit: vec![],
-            total_cw20_deposit: vec![],
+            total_deposit: Default::default(),
+            amount_for_one_task: Default::default(),
             actions: vec![Action {
                 msg,
                 gas_limit: Some(150_000),

--- a/contracts/cw-croncat/src/tasks.rs
+++ b/contracts/cw-croncat/src/tasks.rs
@@ -3,14 +3,14 @@ use crate::slots::Interval;
 use crate::state::{Config, CwCroncat};
 use cosmwasm_std::Storage;
 use cosmwasm_std::{
-    coin, to_binary, Addr, BankMsg, Coin, Deps, DepsMut, Env, MessageInfo, Order, Response,
-    StdResult, SubMsg, Uint128, WasmMsg,
+    to_binary, Addr, BankMsg, Deps, DepsMut, Env, MessageInfo, Order, Response, StdResult, SubMsg,
+    Uint128, WasmMsg,
 };
 use cw20::{Cw20Coin, Cw20CoinVerified, Cw20ExecuteMsg};
 use cw_croncat_core::error::CoreError;
 use cw_croncat_core::msg::{GetSlotHashesResponse, GetSlotIdsResponse, TaskRequest, TaskResponse};
 use cw_croncat_core::traits::{BalancesOperations, Intervals};
-use cw_croncat_core::types::{BoundaryValidated, SlotType, Task};
+use cw_croncat_core::types::{BoundaryValidated, GenericBalance, SlotType, Task};
 
 impl<'a> CwCroncat<'a> {
     /// Returns task data
@@ -212,19 +212,29 @@ impl<'a> CwCroncat<'a> {
             vec![]
         };
         let boundary = BoundaryValidated::validate_boundary(task.boundary, &task.interval)?;
-        let item = Task {
+        let mut item = Task {
             funds_withdrawn_recurring: Uint128::zero(),
             owner_id: owner_id.clone(),
             interval: task.interval,
             boundary,
             stop_on_fail: task.stop_on_fail,
-            total_deposit: info.funds.clone(),
-            total_cw20_deposit: cw20,
+            total_deposit: GenericBalance {
+                native: info.funds.clone(),
+                cw20,
+            },
+            amount_for_one_task: Default::default(),
             actions: task.actions,
             rules: task.rules,
         };
 
-        if !item.is_valid_msg(&env.contract.address, &owner_id, &c.owner_id) {
+        if !item.is_valid_msg_calculate_usage(
+            deps.api,
+            &env.contract.address,
+            &owner_id,
+            &c.owner_id,
+            c.gas_base_fee,
+            c.native_denom.clone(),
+        )? {
             return Err(ContractError::CustomError {
                 val: "Actions message unsupported or invalid message data".to_string(),
             });
@@ -237,27 +247,9 @@ impl<'a> CwCroncat<'a> {
         }
 
         // // Check that balance is sufficient for 1 execution minimum
-        let call_balance_used = item.task_balance_uses(&c.agent_fee, c.gas_base_fee);
-        let min_balance_needed: u128 = if item.interval != Interval::Once {
-            call_balance_used * 2
-        } else {
-            call_balance_used
-        };
-        let attached_native = item
-            .total_deposit
-            .iter()
-            .find(|coin| coin.denom == c.native_denom)
-            .map(|c| c.amount.u128())
-            .unwrap_or_default();
-        if attached_native < min_balance_needed {
-            return Err(ContractError::CustomError {
-                val: format!(
-                    "Not enough task balance to execute job, need at least {min_balance_needed}, attached: {attached_native}",
-                ),
-            });
-        }
-        let task_cw20_balance_uses = item.task_cw20_balance_uses(deps.api)?;
-        item.verify_enough_cw20_balances(&task_cw20_balance_uses)?;
+        let recurring = item.interval != Interval::Once;
+        item.verify_enough_balances(recurring)?;
+
         let hash = item.to_hash();
 
         // Parse interval into a future timestamp, then convert to a slot
@@ -334,7 +326,6 @@ impl<'a> CwCroncat<'a> {
         }
 
         self.config.save(deps.storage, &c)?;
-
         Ok(Response::new()
             .add_attribute("method", "create_task")
             .add_attribute("slot_id", next_id.to_string())
@@ -404,7 +395,7 @@ impl<'a> CwCroncat<'a> {
             &task.owner_id,
             |balances| -> Result<_, ContractError> {
                 let mut balances = balances.unwrap_or_default();
-                balances.checked_add_coins(&task.total_cw20_deposit)?;
+                balances.checked_add_coins(&task.total_deposit.cw20)?;
                 Ok(balances)
             },
         )?;
@@ -412,16 +403,16 @@ impl<'a> CwCroncat<'a> {
         self.config
             .update(storage, |mut c| -> Result<_, ContractError> {
                 c.available_balance
-                    .checked_sub_native(&task.total_deposit)?;
+                    .checked_sub_native(&task.total_deposit.native)?;
                 Ok(c)
             })?;
         // setup sub-msgs for returning any remaining total_deposit to the owner
-        if !task.total_deposit.is_empty() {
+        if !task.total_deposit.native.is_empty() {
             Ok(Response::new()
                 .add_attribute("method", "remove_task")
                 .add_submessage(SubMsg::new(BankMsg::Send {
                     to_address: task.owner_id.into(),
-                    amount: task.total_deposit,
+                    amount: task.total_deposit.native,
                 })))
         } else {
             Ok(Response::new().add_attribute("method", "remove_task"))
@@ -437,11 +428,11 @@ impl<'a> CwCroncat<'a> {
         task_hash: String,
     ) -> Result<Response, ContractError> {
         let hash_vec = task_hash.into_bytes();
-        let task_raw = self.tasks.may_load(deps.storage, &hash_vec)?;
-        if task_raw.is_none() {
-            return Err(ContractError::NoTaskFound {});
-        }
-        let mut task: Task = task_raw.unwrap();
+        let mut task = self
+            .tasks
+            .may_load(deps.storage, &hash_vec)?
+            .ok_or(ContractError::NoTaskFound {})?;
+
         if task.owner_id != info.sender {
             return Err(ContractError::RefillNotTaskOwner {});
         }
@@ -449,32 +440,19 @@ impl<'a> CwCroncat<'a> {
         // Add the attached balance into available_balance
         let mut c: Config = self.config.load(deps.storage)?;
         c.available_balance.checked_add_native(&info.funds)?;
+        task.total_deposit.checked_add_native(&info.funds)?;
+
+        // update the task and the config
         self.config.save(deps.storage, &c)?;
-
-        let mut total_balance: Vec<Coin> = vec![];
-        for t in task.total_deposit.iter() {
-            for f in info.funds.clone() {
-                if f.denom == t.denom {
-                    let amt = t.clone().amount.saturating_add(f.amount);
-                    total_balance.push(coin(amt.into(), t.clone().denom));
-                } else {
-                    total_balance.push(t.clone());
-                }
-            }
-        }
-        task.total_deposit = total_balance;
-
-        // update the task
-        self.tasks
-            .update(deps.storage, &hash_vec, |old| match old {
-                Some(_) => Ok(task.clone()),
-                None => Err(ContractError::CustomError {
-                    val: "Task doesnt exist".to_string(),
-                }),
-            })?;
+        self.tasks.save(deps.storage, &hash_vec, &task)?;
 
         // return the task total
-        let coins_total: Vec<String> = task.total_deposit.iter().map(ToString::to_string).collect();
+        let coins_total: Vec<String> = task
+            .total_deposit
+            .native
+            .iter()
+            .map(ToString::to_string)
+            .collect();
         Ok(Response::new()
             .add_attribute("method", "refill_task")
             .add_attribute("total_deposit", format!("{coins_total:?}")))
@@ -506,8 +484,7 @@ impl<'a> CwCroncat<'a> {
                 return Err(ContractError::RefillNotTaskOwner {});
             }
             // add amount or create with this amount cw20 coins
-            task.total_cw20_deposit
-                .checked_add_coins(&cw20_coins_validated)?;
+            task.total_deposit.checked_add_cw20(&cw20_coins_validated)?;
             Ok(task)
         })?;
 
@@ -525,7 +502,8 @@ impl<'a> CwCroncat<'a> {
         // used `update` here to not clone task_hash
 
         let total_cw20_string: Vec<String> = task
-            .total_cw20_deposit
+            .total_deposit
+            .cw20
             .iter()
             .map(ToString::to_string)
             .collect();
@@ -684,8 +662,11 @@ mod tests {
                 end: None,
             },
             stop_on_fail: false,
-            total_deposit: coins(37, "atom"),
-            total_cw20_deposit: vec![],
+            total_deposit: GenericBalance {
+                native: coins(37, "atom"),
+                cw20: Default::default(),
+            },
+            amount_for_one_task: Default::default(),
             actions: vec![Action {
                 msg,
                 gas_limit: Some(150_000),
@@ -1442,7 +1423,6 @@ mod tests {
         let stake = StakingMsg::Delegate { validator, amount };
         let msg: CosmosMsg = stake.clone().into();
         let gas_limit = 150_000;
-        let agent_fee = 5;
 
         let create_task_msg = ExecuteMsg::CreateTask {
             task: TaskRequest {
@@ -1458,14 +1438,24 @@ mod tests {
             },
         };
         // create 1 token off task
-        let amount_for_one_task = gas_limit + agent_fee;
-        let res = app.execute_contract(
-            Addr::unchecked(ANYONE),
-            contract_addr.clone(),
-            &create_task_msg,
-            &coins(u128::from(amount_for_one_task * 2 - 1), "atom"),
+        let amount_for_one_task = gas_limit;
+        let res: ContractError = app
+            .execute_contract(
+                Addr::unchecked(ANYONE),
+                contract_addr.clone(),
+                &create_task_msg,
+                &coins(u128::from(amount_for_one_task * 2 - 1), "atom"),
+            )
+            .unwrap_err()
+            .downcast()
+            .unwrap();
+        assert_eq!(
+            res,
+            ContractError::CoreError(CoreError::NotEnoughNative {
+                denom: "atom".to_string(),
+                lack: Uint128::from(1u128)
+            })
         );
-        assert!(format!("{res:?}").contains("Not enough task balance to execute job"));
 
         // create a task
         let res = app.execute_contract(
@@ -1487,7 +1477,6 @@ mod tests {
         let stake = StakingMsg::Delegate { validator, amount };
         let msg: CosmosMsg = stake.clone().into();
         let gas_limit = GAS_BASE_FEE_JUNO;
-        let agent_fee = 5;
 
         let create_task_msg = ExecuteMsg::CreateTask {
             task: TaskRequest {
@@ -1503,14 +1492,24 @@ mod tests {
             },
         };
         // create 1 token off task
-        let amount_for_one_task = gas_limit + agent_fee;
-        let res = app.execute_contract(
-            Addr::unchecked(ANYONE),
-            contract_addr.clone(),
-            &create_task_msg,
-            &coins(u128::from(amount_for_one_task * 2 - 1), "atom"),
+        let amount_for_one_task = gas_limit;
+        let res: ContractError = app
+            .execute_contract(
+                Addr::unchecked(ANYONE),
+                contract_addr.clone(),
+                &create_task_msg,
+                &coins(u128::from(amount_for_one_task * 2 - 1), "atom"),
+            )
+            .unwrap_err()
+            .downcast()
+            .unwrap();
+        assert_eq!(
+            res,
+            ContractError::CoreError(CoreError::NotEnoughNative {
+                denom: "atom".to_string(),
+                lack: Uint128::from(1u128)
+            })
         );
-        assert!(format!("{res:?}").contains("Not enough task balance to execute job"));
 
         // create a task
         let res = app.execute_contract(

--- a/packages/cw-croncat-core/schema/croncat.json
+++ b/packages/cw-croncat-core/schema/croncat.json
@@ -1226,12 +1226,12 @@
       "type": "object",
       "required": [
         "actions",
+        "amount_for_one_task",
         "boundary",
         "funds_withdrawn_recurring",
         "interval",
         "owner_id",
         "stop_on_fail",
-        "total_cw20_deposit",
         "total_deposit"
       ],
       "properties": {
@@ -1241,6 +1241,9 @@
           "items": {
             "$ref": "#/definitions/Action_for_Empty"
           }
+        },
+        "amount_for_one_task": {
+          "$ref": "#/definitions/GenericBalance"
         },
         "boundary": {
           "$ref": "#/definitions/BoundaryValidated"
@@ -1278,18 +1281,13 @@
           "description": "Defines if this task can continue until balance runs out",
           "type": "boolean"
         },
-        "total_cw20_deposit": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Cw20CoinVerified"
-          }
-        },
         "total_deposit": {
           "description": "NOTE: Only tally native balance here, manager can maintain token/balances outside of tasks",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Coin"
-          }
+          "allOf": [
+            {
+              "$ref": "#/definitions/GenericBalance"
+            }
+          ]
         }
       }
     },

--- a/packages/cw-croncat-core/schema/query_msg.json
+++ b/packages/cw-croncat-core/schema/query_msg.json
@@ -551,6 +551,27 @@
       "description": "An empty struct that serves as a placeholder in different places, such as contracts that don't set a custom message.\n\nIt is designed to be expressable in correct JSON and JSON Schema but contains no meaningful data. Previously we used enums without cases, but those cannot represented as valid JSON Schema (https://github.com/CosmWasm/cosmwasm/issues/451)",
       "type": "object"
     },
+    "GenericBalance": {
+      "type": "object",
+      "required": [
+        "cw20",
+        "native"
+      ],
+      "properties": {
+        "cw20": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Cw20CoinVerified"
+          }
+        },
+        "native": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Coin"
+          }
+        }
+      }
+    },
     "GovMsg": {
       "oneOf": [
         {
@@ -883,12 +904,12 @@
       "type": "object",
       "required": [
         "actions",
+        "amount_for_one_task",
         "boundary",
         "funds_withdrawn_recurring",
         "interval",
         "owner_id",
         "stop_on_fail",
-        "total_cw20_deposit",
         "total_deposit"
       ],
       "properties": {
@@ -898,6 +919,9 @@
           "items": {
             "$ref": "#/definitions/Action_for_Empty"
           }
+        },
+        "amount_for_one_task": {
+          "$ref": "#/definitions/GenericBalance"
         },
         "boundary": {
           "$ref": "#/definitions/BoundaryValidated"
@@ -935,18 +959,13 @@
           "description": "Defines if this task can continue until balance runs out",
           "type": "boolean"
         },
-        "total_cw20_deposit": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Cw20CoinVerified"
-          }
-        },
         "total_deposit": {
           "description": "NOTE: Only tally native balance here, manager can maintain token/balances outside of tasks",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Coin"
-          }
+          "allOf": [
+            {
+              "$ref": "#/definitions/GenericBalance"
+            }
+          ]
         }
       }
     },

--- a/packages/cw-croncat-core/src/error.rs
+++ b/packages/cw-croncat-core/src/error.rs
@@ -15,6 +15,9 @@ pub enum CoreError {
     #[error("Not enough cw20 balance of {addr}, need {lack} more")]
     NotEnoughCw20 { addr: String, lack: Uint128 },
 
+    #[error("Not enough native balance of {denom}, need {lack} more")]
+    NotEnoughNative { denom: String, lack: Uint128 },
+
     #[error("invalid cosmwasm message")]
     InvalidWasmMsg {},
 }

--- a/packages/cw-croncat-core/src/msg.rs
+++ b/packages/cw-croncat-core/src/msg.rs
@@ -267,8 +267,8 @@ impl From<Task> for TaskResponse {
             interval: task.interval,
             boundary,
             stop_on_fail: task.stop_on_fail,
-            total_deposit: task.total_deposit,
-            total_cw20_deposit: task.total_cw20_deposit,
+            total_deposit: task.total_deposit.native,
+            total_cw20_deposit: task.total_deposit.cw20,
             actions: task.actions,
             rules: task.rules,
         }
@@ -333,8 +333,8 @@ mod tests {
                 end: Some(44),
             },
             stop_on_fail: false,
-            total_deposit: vec![],
-            total_cw20_deposit: vec![],
+            total_deposit: Default::default(),
+            amount_for_one_task: Default::default(),
             actions: vec![Action {
                 msg,
                 gas_limit: Some(150_000),

--- a/packages/cw-croncat-core/src/traits.rs
+++ b/packages/cw-croncat-core/src/traits.rs
@@ -30,7 +30,7 @@ pub trait ResultFailed {
 }
 
 pub trait Intervals {
-    fn next(&self, env: Env, boundary: BoundaryValidated) -> (u64, SlotType);
+    fn next(&self, env: &Env, boundary: BoundaryValidated) -> (u64, SlotType);
     fn is_valid(&self) -> bool;
 }
 

--- a/packages/cw-croncat-core/src/traits.rs
+++ b/packages/cw-croncat-core/src/traits.rs
@@ -25,6 +25,10 @@ pub trait BalancesOperations<'a, T, Rhs> {
     fn checked_sub_coins(&mut self, sub: Rhs) -> Result<(), CoreError>;
 }
 
+pub trait ResultFailed {
+    fn failed(&self) -> bool;
+}
+
 pub trait Intervals {
     fn next(&self, env: Env, boundary: BoundaryValidated) -> (u64, SlotType);
     fn is_valid(&self) -> bool;

--- a/packages/cw-croncat-core/src/types.rs
+++ b/packages/cw-croncat-core/src/types.rs
@@ -529,6 +529,11 @@ impl GenericBalance {
     pub fn checked_sub_cw20(&mut self, sub: &[Cw20CoinVerified]) -> Result<(), CoreError> {
         self.cw20.checked_sub_coins(sub)
     }
+
+    pub fn checked_sub_generic(&mut self, sub: &GenericBalance) -> Result<(), CoreError> {
+        self.checked_sub_native(&sub.native)?;
+        self.checked_sub_cw20(&sub.cw20)
+    }
 }
 
 impl ResultFailed for SubMsgResult {

--- a/packages/cw-croncat-core/src/types.rs
+++ b/packages/cw-croncat-core/src/types.rs
@@ -546,7 +546,7 @@ impl ResultFailed for SubMsgResult {
     }
 }
 
-fn get_next_block_limited(env: Env, boundary: BoundaryValidated) -> (u64, SlotType) {
+fn get_next_block_limited(env: &Env, boundary: BoundaryValidated) -> (u64, SlotType) {
     let current_block_height = env.block.height;
 
     let next_block_height = match boundary.start {
@@ -570,7 +570,7 @@ fn get_next_block_limited(env: Env, boundary: BoundaryValidated) -> (u64, SlotTy
 // So either:
 // - Boundary specifies a start/end that block offsets can be computed from
 // - Block offset will truncate to specific modulo offsets
-fn get_next_block_by_offset(env: Env, boundary: BoundaryValidated, block: u64) -> (u64, SlotType) {
+fn get_next_block_by_offset(env: &Env, boundary: BoundaryValidated, block: u64) -> (u64, SlotType) {
     let current_block_height = env.block.height;
     let modulo_block = current_block_height.saturating_sub(current_block_height % block) + block;
 
@@ -605,7 +605,7 @@ fn get_next_block_by_offset(env: Env, boundary: BoundaryValidated, block: u64) -
 }
 
 impl Intervals for Interval {
-    fn next(&self, env: Env, boundary: BoundaryValidated) -> (u64, SlotType) {
+    fn next(&self, env: &Env, boundary: BoundaryValidated) -> (u64, SlotType) {
         match self {
             // return the first block within a specific range that can be triggered 1 time.
             Interval::Once => get_next_block_limited(env, boundary),

--- a/packages/cw-croncat-core/src/types.rs
+++ b/packages/cw-croncat-core/src/types.rs
@@ -166,6 +166,7 @@ pub struct Action<T = Empty> {
 }
 
 impl Action {
+    // Checking how much native coins sent in this action
     pub fn bank_sent(&self) -> Option<&[Coin]> {
         if let CosmosMsg::Bank(BankMsg::Send { amount, .. }) = &self.msg {
             Some(amount)
@@ -174,6 +175,7 @@ impl Action {
         }
     }
 
+    // Checking how much cw20 coins sent in this action
     pub fn cw20_sent(&self, api: &dyn Api) -> Option<Cw20CoinVerified> {
         if let CosmosMsg::Wasm(WasmMsg::Execute {
             msg, contract_addr, ..
@@ -182,6 +184,7 @@ impl Action {
             if let Ok(cw20_msg) = cosmwasm_std::from_binary(msg) {
                 return match cw20_msg {
                     Cw20ExecuteMsg::Send { amount, .. } => Some(Cw20CoinVerified {
+                        // unwraping safe here because we checked it at
                         address: api.addr_validate(contract_addr).unwrap(),
                         amount,
                     }),

--- a/types/contract/CwCroncatContract.ts
+++ b/types/contract/CwCroncatContract.ts
@@ -296,14 +296,14 @@ export interface GetWalletBalancesResponse {
 }
 export interface Task {
   actions: ActionForEmpty[];
+  amount_for_one_task: GenericBalance;
   boundary: BoundaryValidated;
   funds_withdrawn_recurring: Uint128;
   interval: Interval;
   owner_id: Addr;
   rules?: Rule[] | null;
   stop_on_fail: boolean;
-  total_cw20_deposit: Cw20CoinVerified[];
-  total_deposit: Coin[];
+  total_deposit: GenericBalance;
   [k: string]: unknown;
 }
 export interface BoundaryValidated {


### PR DESCRIPTION
Closes #54.
New stuff:

- Support of multiple action in one task. 
  - Only the last action will call `proxy_callback()`, and actions before that used to check used deposit in cases of transfers
- Validating if task has enough deposit to reschedule this task.
- Calculating amount of used tokens at `create_task()`, merged it with `is_valid_msg()`, so we don't iterate `actions` multiple times
  - Storing it in the task itself. What you think, should we show `used_deposit` in the `TaskResponse`?
  - Thinking about better naming for `is_valid_msg()` now? What you think about `is_valid_msg_calculate_usage()`
- Calculating gas usage and agent_base_reward right in the `proxy_call`
- Calculate task balance changes in the reply(so we can properly change it after TX is passed)

Fixes:

- After agent withdraw his balances we decrease his balance in the state(CRITICAL, infinite withdraw)
- Wrong calculation of agent base reward
- `send_base_agent_reward()` didn't sent any funds, cause it was followed by Err(), which rollbacks the state.
- Refunds if task balance is empty at `remove_task()`. If we try to send zero coins it will fail the tx and rollback state(and we really don't want this happen during the `proxy_call()`) 
- Removed  redundant clones
- Some minor refactors
