### PR TITLE
Fix balance methods in cw-rules

### DIFF
--- a/contracts/cw-rules/src/contract.rs
+++ b/contracts/cw-rules/src/contract.rs
@@ -127,16 +127,9 @@ fn query_has_balance_gt(
         Balance::Native(required_native) => {
             let balances = deps.querier.query_all_balances(valid_address)?;
             let required_vec = required_native.into_vec();
-            let mut has_balance = true;
-            for required_coin in required_vec {
-                if (required_coin.amount != Uint128::zero())
-                    && (!has_coins(&balances, &required_coin))
-                {
-                    has_balance = false;
-                    break;
-                }
-            }
-            has_balance
+            required_vec.iter().all(|required| {
+                required.amount == Uint128::zero() || has_coins(&balances, required)
+            })
         }
         Balance::Cw20(required_cw20) => {
             let balance_response: BalanceResponse = deps.querier.query_wasm_smart(

--- a/contracts/cw-rules/src/contract.rs
+++ b/contracts/cw-rules/src/contract.rs
@@ -5,7 +5,8 @@
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
-    has_coins, to_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdResult, Uint128,
+    coin, has_coins, to_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdResult,
+    Uint128,
 };
 use cw2::set_contract_version;
 use cw20::{Balance, BalanceResponse};
@@ -100,15 +101,11 @@ fn query_get_cw20_balance(
     address: String,
 ) -> StdResult<RuleResponse<Option<Binary>>> {
     let valid_cw20 = deps.api.addr_validate(&cw20_contract)?;
-    let balance: BalanceResponse = deps
+    let balance_response: BalanceResponse = deps
         .querier
         .query_wasm_smart(valid_cw20, &cw20::Cw20QueryMsg::Balance { address })?;
-    let amount = if balance.balance.is_zero() {
-        None
-    } else {
-        Some(to_binary(&balance.balance)?)
-    };
-    Ok((true, amount))
+    let coin = coin(balance_response.balance.into(), cw20_contract);
+    Ok((true, to_binary(&coin).ok()))
 }
 
 fn query_has_balance_gt(

--- a/contracts/cw-rules/src/contract.rs
+++ b/contracts/cw-rules/src/contract.rs
@@ -62,10 +62,10 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
             cw20_contract,
             address,
         } => to_binary(&query_get_cw20_balance(deps, cw20_contract, address)?),
-        QueryMsg::HasBalanceGt {
+        QueryMsg::HasBalanceGte {
             address,
             required_balance,
-        } => to_binary(&query_has_balance_gt(deps, address, required_balance)?),
+        } => to_binary(&query_has_balance_gte(deps, address, required_balance)?),
         QueryMsg::CheckOwnerOfNFT {
             address,
             nft_address,
@@ -117,7 +117,7 @@ fn query_get_cw20_balance(
     Ok((true, to_binary(&coin).ok()))
 }
 
-fn query_has_balance_gt(
+fn query_has_balance_gte(
     deps: Deps,
     address: String,
     required_balance: Balance,

--- a/contracts/cw-rules/src/contract.rs
+++ b/contracts/cw-rules/src/contract.rs
@@ -90,12 +90,8 @@ fn query_get_balance(
     denom: String,
 ) -> StdResult<RuleResponse<Option<Binary>>> {
     let valid_addr = deps.api.addr_validate(&address)?;
-    let amount = deps.querier.query_balance(valid_addr, denom)?.amount;
-    if amount.is_zero() {
-        Ok((true, None))
-    } else {
-        Ok((true, to_binary(&amount).ok()))
-    }
+    let coin = deps.querier.query_balance(valid_addr, denom)?;
+    Ok((true, to_binary(&coin).ok()))
 }
 
 fn query_get_cw20_balance(

--- a/contracts/cw-rules/src/contract.rs
+++ b/contracts/cw-rules/src/contract.rs
@@ -62,7 +62,7 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
             cw20_contract,
             address,
         } => to_binary(&query_get_cw20_balance(deps, cw20_contract, address)?),
-        QueryMsg::HasBalanceGT {
+        QueryMsg::HasBalanceGt {
             address,
             required_balance,
         } => to_binary(&query_has_balance_gt(deps, address, required_balance)?),

--- a/contracts/cw-rules/src/contract.rs
+++ b/contracts/cw-rules/src/contract.rs
@@ -6,8 +6,8 @@ use serde_json::Value;
 #[cfg(not(feature = "library"))]
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
-    coin, Uint128, from_binary, has_coins, to_binary, to_vec, Binary, Deps, DepsMut, Empty, Env, MessageInfo,
-    QueryRequest, Response, StdError, StdResult, WasmQuery,
+    coin, from_binary, has_coins, to_binary, to_vec, Binary, Deps, DepsMut, Empty, Env,
+    MessageInfo, QueryRequest, Response, StdError, StdResult, Uint128, WasmQuery,
 };
 use cw2::set_contract_version;
 use cw20::{Balance, BalanceResponse};

--- a/contracts/cw-rules/src/msg.rs
+++ b/contracts/cw-rules/src/msg.rs
@@ -27,7 +27,7 @@ pub enum QueryMsg {
         cw20_contract: String,
         address: String,
     },
-    HasBalanceGT {
+    HasBalanceGt {
         address: String,
         required_balance: Balance,
     },

--- a/contracts/cw-rules/src/msg.rs
+++ b/contracts/cw-rules/src/msg.rs
@@ -27,7 +27,7 @@ pub enum QueryMsg {
         cw20_contract: String,
         address: String,
     },
-    HasBalanceGt {
+    HasBalanceGte {
         address: String,
         required_balance: Balance,
     },

--- a/contracts/cw-rules/src/msg.rs
+++ b/contracts/cw-rules/src/msg.rs
@@ -26,8 +26,8 @@ pub enum QueryMsg {
         cw20_contract: String,
         address: String,
     },
-    HasBalance {
-        balance: Balance,
+    HasBalanceGT {
+        address: String,
         required_balance: Balance,
     },
     CheckOwnerOfNFT {

--- a/contracts/cw-rules/src/tests/balance.rs
+++ b/contracts/cw-rules/src/tests/balance.rs
@@ -130,7 +130,7 @@ fn test_get_balance() -> StdResult<()> {
 fn test_get_cw20_balance() -> StdResult<()> {
     let (app, contract_addr, cw20_contract) = proper_instantiate();
 
-    // Return some amount
+    // Return coin
     let msg = QueryMsg::GetCW20Balance {
         cw20_contract: cw20_contract.to_string(),
         address: ANYONE.to_string(),
@@ -140,9 +140,9 @@ fn test_get_cw20_balance() -> StdResult<()> {
         .query_wasm_smart(contract_addr.clone(), &msg)
         .unwrap();
     assert!(res.0);
-    assert_eq!(res.1.unwrap(), to_binary("15")?);
+    assert_eq!(res.1.unwrap(), to_binary(&coin(15, &cw20_contract))?);
 
-    // Return None if balance is zero
+    // Return coin if balance is zero
     let msg = QueryMsg::GetCW20Balance {
         cw20_contract: cw20_contract.to_string(),
         address: ADMIN_CW20.to_string(),
@@ -152,9 +152,9 @@ fn test_get_cw20_balance() -> StdResult<()> {
         .query_wasm_smart(contract_addr.clone(), &msg)
         .unwrap();
     assert!(res.0);
-    assert_eq!(res.1, None);
+    assert_eq!(res.1.unwrap(), to_binary(&coin(0, &cw20_contract))?);
 
-    // Address doesn't exist
+    // If address doesn't exist, return coin with zero amount
     let msg = QueryMsg::GetCW20Balance {
         cw20_contract: cw20_contract.to_string(),
         address: ANOTHER.to_string(),
@@ -164,9 +164,9 @@ fn test_get_cw20_balance() -> StdResult<()> {
         .query_wasm_smart(contract_addr.clone(), &msg)
         .unwrap();
     assert!(res.0);
-    assert_eq!(res.1, None);
+    assert_eq!(res.1.unwrap(), to_binary(&coin(0, &cw20_contract))?);
 
-    // Error
+    // Error if called wrong cw20_contract
     let msg = QueryMsg::GetCW20Balance {
         cw20_contract: contract_addr.to_string(),
         address: ANYONE.to_string(),

--- a/contracts/cw-rules/src/tests/balance.rs
+++ b/contracts/cw-rules/src/tests/balance.rs
@@ -183,7 +183,7 @@ fn test_has_balance_native() -> StdResult<()> {
     let (app, contract_addr, _) = proper_instantiate();
 
     // Return true if address has more coins
-    let msg = QueryMsg::HasBalanceGt {
+    let msg = QueryMsg::HasBalanceGte {
         address: ANYONE.to_string(),
         required_balance: Balance::Native(NativeBalance(coins(
             900_000u128,
@@ -198,7 +198,7 @@ fn test_has_balance_native() -> StdResult<()> {
     assert_eq!(res.1, None);
 
     // Return true if real and required balances are equal
-    let msg = QueryMsg::HasBalanceGt {
+    let msg = QueryMsg::HasBalanceGte {
         address: ANYONE.to_string(),
         required_balance: Balance::Native(NativeBalance(coins(
             1_000_000u128,
@@ -213,7 +213,7 @@ fn test_has_balance_native() -> StdResult<()> {
     assert_eq!(res.1, None);
 
     // Return false if address has less coins
-    let msg = QueryMsg::HasBalanceGt {
+    let msg = QueryMsg::HasBalanceGte {
         address: ANYONE.to_string(),
         required_balance: Balance::Native(NativeBalance(coins(
             1_100_000u128,
@@ -227,8 +227,20 @@ fn test_has_balance_native() -> StdResult<()> {
     assert!(!res.0);
     assert_eq!(res.1, None);
 
+    // Return false if address has zero coins
+    let msg = QueryMsg::HasBalanceGte {
+        address: ANYONE.to_string(),
+        required_balance: Balance::Native(NativeBalance(coins(1_000_000u128, "juno".to_string()))),
+    };
+    let res: RuleResponse<Option<Binary>> = app
+        .wrap()
+        .query_wasm_smart(contract_addr.clone(), &msg)
+        .unwrap();
+    assert!(!res.0);
+    assert_eq!(res.1, None);
+
     // Return false if the account doesn't exist and required_balance is not zero
-    let msg = QueryMsg::HasBalanceGt {
+    let msg = QueryMsg::HasBalanceGte {
         address: ANOTHER.to_string(),
         required_balance: Balance::Native(NativeBalance(coins(1u128, NATIVE_DENOM.to_string()))),
     };
@@ -240,7 +252,7 @@ fn test_has_balance_native() -> StdResult<()> {
     assert_eq!(res.1, None);
 
     // Return true if required balance is zero
-    let msg = QueryMsg::HasBalanceGt {
+    let msg = QueryMsg::HasBalanceGte {
         address: ANOTHER.to_string(),
         required_balance: Balance::Native(NativeBalance(coins(0u128, NATIVE_DENOM.to_string()))),
     };
@@ -259,7 +271,7 @@ fn test_has_balance_cw20() -> StdResult<()> {
     let (app, contract_addr, cw20_contract) = proper_instantiate();
 
     // Return true if address has more coins
-    let msg = QueryMsg::HasBalanceGt {
+    let msg = QueryMsg::HasBalanceGte {
         address: ANYONE.to_string(),
         required_balance: Balance::Cw20(Cw20CoinVerified {
             address: Addr::unchecked(&cw20_contract),
@@ -274,7 +286,7 @@ fn test_has_balance_cw20() -> StdResult<()> {
     assert_eq!(res.1, None);
 
     // Return true if real and required balances are equal
-    let msg = QueryMsg::HasBalanceGt {
+    let msg = QueryMsg::HasBalanceGte {
         address: ANYONE.to_string(),
         required_balance: Balance::Cw20(Cw20CoinVerified {
             address: Addr::unchecked(&cw20_contract),
@@ -289,7 +301,7 @@ fn test_has_balance_cw20() -> StdResult<()> {
     assert_eq!(res.1, None);
 
     // Return false if address has less coins
-    let msg = QueryMsg::HasBalanceGt {
+    let msg = QueryMsg::HasBalanceGte {
         address: ANYONE.to_string(),
         required_balance: Balance::Cw20(Cw20CoinVerified {
             address: Addr::unchecked(&cw20_contract),
@@ -304,7 +316,7 @@ fn test_has_balance_cw20() -> StdResult<()> {
     assert_eq!(res.1, None);
 
     // Return false if the account doesn't exist and required_balance is not zero
-    let msg = QueryMsg::HasBalanceGt {
+    let msg = QueryMsg::HasBalanceGte {
         address: ANOTHER.to_string(),
         required_balance: Balance::Cw20(Cw20CoinVerified {
             address: Addr::unchecked(&cw20_contract),
@@ -319,7 +331,7 @@ fn test_has_balance_cw20() -> StdResult<()> {
     assert_eq!(res.1, None);
 
     // Return true if required balance is zero
-    let msg = QueryMsg::HasBalanceGt {
+    let msg = QueryMsg::HasBalanceGte {
         address: ANOTHER.to_string(),
         required_balance: Balance::Cw20(Cw20CoinVerified {
             address: Addr::unchecked(&cw20_contract),

--- a/contracts/cw-rules/src/tests/balance.rs
+++ b/contracts/cw-rules/src/tests/balance.rs
@@ -99,7 +99,7 @@ fn test_get_balance() -> StdResult<()> {
         .query_wasm_smart(contract_addr.clone(), &msg)
         .unwrap();
     assert!(res.0);
-    assert_eq!(res.1.unwrap(), to_binary("1000000")?);
+    assert_eq!(res.1.unwrap(), to_binary(&coin(1000000, NATIVE_DENOM))?);
 
     // Balance with another denom is zero
     let msg = QueryMsg::GetBalance {
@@ -111,9 +111,9 @@ fn test_get_balance() -> StdResult<()> {
         .query_wasm_smart(contract_addr.clone(), &msg)
         .unwrap();
     assert!(res.0);
-    assert_eq!(res.1, None);
+    assert_eq!(res.1.unwrap(), to_binary(&coin(0, "juno"))?);
 
-    // Address doesn't exist
+    // Address doesn't exist, return zero balance
     let msg = QueryMsg::GetBalance {
         address: ANOTHER.to_string(),
         denom: NATIVE_DENOM.to_string(),
@@ -121,7 +121,7 @@ fn test_get_balance() -> StdResult<()> {
     let res: RuleResponse<Option<Binary>> =
         app.wrap().query_wasm_smart(contract_addr, &msg).unwrap();
     assert!(res.0);
-    assert_eq!(res.1, None);
+    assert_eq!(res.1.unwrap(), to_binary(&coin(0, NATIVE_DENOM))?);
 
     Ok(())
 }

--- a/contracts/cw-rules/src/tests/balance.rs
+++ b/contracts/cw-rules/src/tests/balance.rs
@@ -183,7 +183,7 @@ fn test_has_balance_native() -> StdResult<()> {
     let (app, contract_addr, _) = proper_instantiate();
 
     // Return true if address has more coins
-    let msg = QueryMsg::HasBalanceGT {
+    let msg = QueryMsg::HasBalanceGt {
         address: ANYONE.to_string(),
         required_balance: Balance::Native(NativeBalance(coins(
             900_000u128,
@@ -198,7 +198,7 @@ fn test_has_balance_native() -> StdResult<()> {
     assert_eq!(res.1, None);
 
     // Return true if real and required balances are equal
-    let msg = QueryMsg::HasBalanceGT {
+    let msg = QueryMsg::HasBalanceGt {
         address: ANYONE.to_string(),
         required_balance: Balance::Native(NativeBalance(coins(
             1_000_000u128,
@@ -213,7 +213,7 @@ fn test_has_balance_native() -> StdResult<()> {
     assert_eq!(res.1, None);
 
     // Return false if address has less coins
-    let msg = QueryMsg::HasBalanceGT {
+    let msg = QueryMsg::HasBalanceGt {
         address: ANYONE.to_string(),
         required_balance: Balance::Native(NativeBalance(coins(
             1_100_000u128,
@@ -228,7 +228,7 @@ fn test_has_balance_native() -> StdResult<()> {
     assert_eq!(res.1, None);
 
     // Return false if the account doesn't exist and required_balance is not zero
-    let msg = QueryMsg::HasBalanceGT {
+    let msg = QueryMsg::HasBalanceGt {
         address: ANOTHER.to_string(),
         required_balance: Balance::Native(NativeBalance(coins(1u128, NATIVE_DENOM.to_string()))),
     };
@@ -240,7 +240,7 @@ fn test_has_balance_native() -> StdResult<()> {
     assert_eq!(res.1, None);
 
     // Return true if required balance is zero
-    let msg = QueryMsg::HasBalanceGT {
+    let msg = QueryMsg::HasBalanceGt {
         address: ANOTHER.to_string(),
         required_balance: Balance::Native(NativeBalance(coins(0u128, NATIVE_DENOM.to_string()))),
     };
@@ -259,7 +259,7 @@ fn test_has_balance_cw20() -> StdResult<()> {
     let (app, contract_addr, cw20_contract) = proper_instantiate();
 
     // Return true if address has more coins
-    let msg = QueryMsg::HasBalanceGT {
+    let msg = QueryMsg::HasBalanceGt {
         address: ANYONE.to_string(),
         required_balance: Balance::Cw20(Cw20CoinVerified {
             address: Addr::unchecked(&cw20_contract),
@@ -274,7 +274,7 @@ fn test_has_balance_cw20() -> StdResult<()> {
     assert_eq!(res.1, None);
 
     // Return true if real and required balances are equal
-    let msg = QueryMsg::HasBalanceGT {
+    let msg = QueryMsg::HasBalanceGt {
         address: ANYONE.to_string(),
         required_balance: Balance::Cw20(Cw20CoinVerified {
             address: Addr::unchecked(&cw20_contract),
@@ -289,7 +289,7 @@ fn test_has_balance_cw20() -> StdResult<()> {
     assert_eq!(res.1, None);
 
     // Return false if address has less coins
-    let msg = QueryMsg::HasBalanceGT {
+    let msg = QueryMsg::HasBalanceGt {
         address: ANYONE.to_string(),
         required_balance: Balance::Cw20(Cw20CoinVerified {
             address: Addr::unchecked(&cw20_contract),
@@ -304,7 +304,7 @@ fn test_has_balance_cw20() -> StdResult<()> {
     assert_eq!(res.1, None);
 
     // Return false if the account doesn't exist and required_balance is not zero
-    let msg = QueryMsg::HasBalanceGT {
+    let msg = QueryMsg::HasBalanceGt {
         address: ANOTHER.to_string(),
         required_balance: Balance::Cw20(Cw20CoinVerified {
             address: Addr::unchecked(&cw20_contract),
@@ -319,7 +319,7 @@ fn test_has_balance_cw20() -> StdResult<()> {
     assert_eq!(res.1, None);
 
     // Return true if required balance is zero
-    let msg = QueryMsg::HasBalanceGT {
+    let msg = QueryMsg::HasBalanceGt {
         address: ANOTHER.to_string(),
         required_balance: Balance::Cw20(Cw20CoinVerified {
             address: Addr::unchecked(&cw20_contract),


### PR DESCRIPTION
Changed `query_has_balance` and `query_get_cw20_balance` so that they return `Coin` in `Binary`.
Renamed `query_has_balance` to `query_has_balance_gt` and implemented checking that the given address has more coins than the given balance.

Also I'm not sure whether `query_get_cw20_balance` should return `Coin`.  I think `Cw20CoinVerified` is more suitable as it has `address` instead of `denom`:
```
pub struct Cw20CoinVerified {
    pub address: Addr,
    pub amount: Uint128,
}
```
Another option is to return `Balance` in both `query_has_balance` and `query_get_cw20_balance`
```
pub enum Balance {
    Native(NativeBalance),
    Cw20(Cw20CoinVerified),
}
```