### PR TITLE
Removed floats from `cw-rules`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,6 +423,7 @@ dependencies = [
  "cw721-base",
  "schemars",
  "serde",
+ "serde-cw-value",
  "serde_json",
  "thiserror",
  "voting",
@@ -1118,6 +1119,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f747710de3dcd43b88c9168773254e809d8ddbdf9653b84e2554ab219f17860"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-cw-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75d32da6b8ed758b7d850b6c3c08f1d7df51a4df3cb201296e63e34a78e99d4"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/contracts/cw-rules/Cargo.toml
+++ b/contracts/cw-rules/Cargo.toml
@@ -42,12 +42,13 @@ cw721-base = "0.13.2"
 cw20 = "0.13"
 schemars = "0.8.8"
 serde = { version = "1.0.137", default-features = false, features = ["derive"] }
-serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 thiserror = { version = "1.0.31" }
 cw4 = "0.14.0"
 cw4-group = "0.14.0"
 base64 = "0.13"
 voting = { version = "0.2.0", git = "https://github.com/DA0-DA0/dao-contracts" }
+# This thing saved our lives thanks @hashedone for implementing it
+serde-cw-value = "0.7.0"
 
 [dev-dependencies]
 cosmwasm-schema = "1.0.0"
@@ -67,3 +68,4 @@ cw-core-interface = { version = "0.2.0", git = "https://github.com/DA0-DA0/dao-c
 cw4 = "0.14.0"
 cw4-group = "0.14.0"
 base64 = "0.13.0"
+serde_json = { version = "1.0", default-features = false, features = ["alloc"] }

--- a/contracts/cw-rules/src/helpers.rs
+++ b/contracts/cw-rules/src/helpers.rs
@@ -2,7 +2,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use cosmwasm_std::{StdError, StdResult, Uint512};
-use serde_json::Value;
+use serde_cw_value::Value;
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
@@ -15,97 +15,85 @@ pub enum ValueOrdering {
 }
 
 pub trait ValueOrd {
-    fn lt(&self, other: &Self) -> StdResult<bool>;
-    fn le(&self, other: &Self) -> StdResult<bool>;
-    fn bt(&self, other: &Self) -> StdResult<bool>;
-    fn be(&self, other: &Self) -> StdResult<bool>;
+    fn lt_g(&self, other: &Self) -> StdResult<bool>;
+    fn le_g(&self, other: &Self) -> StdResult<bool>;
+    fn bt_g(&self, other: &Self) -> StdResult<bool>;
+    fn be_g(&self, other: &Self) -> StdResult<bool>;
     fn equal(&self, other: &Self) -> bool;
 }
 
 /// Only supporting numbers and big numbers for now
 impl ValueOrd for Value {
-    fn lt(&self, other: &Self) -> StdResult<bool> {
-        if let Value::String(strnum) = self {
-            let bigint: Uint512 = strnum.parse()?;
-            let oth_bigint = other.as_str();
-            if let Some(oth) = oth_bigint {
-                return Ok(bigint < oth.parse()?);
+    fn lt_g(&self, other: &Self) -> StdResult<bool> {
+        match (self, other) {
+            (Value::String(str_num), Value::String(oth)) => {
+                let big_num: Uint512 = str_num.parse()?;
+                let big_oth: Uint512 = oth.parse()?;
+                Ok(big_num < big_oth)
             }
-        } else {
-            let num = self.as_u64();
-            let oth_num = other.as_u64();
-            if let (Some(n), Some(oth)) = (num, oth_num) {
-                return Ok(n < oth);
-            }
-        };
-
-        Err(StdError::parse_err(
-            "number",
-            "Failed to parse to Uint512 and to u64",
-        ))
+            (Value::U64(n), Value::U64(o)) => Ok(n < o),
+            (Value::U32(n), Value::U32(o)) => Ok(n < o),
+            (Value::U16(n), Value::U16(o)) => Ok(n < o),
+            (Value::U8(n), Value::U8(o)) => Ok(n < o),
+            _ => Err(StdError::parse_err(
+                "number",
+                "Failed to parse to Uint512 and to u64",
+            )),
+        }
     }
 
-    fn le(&self, other: &Self) -> StdResult<bool> {
-        if let Value::String(strnum) = self {
-            let bigint: Uint512 = strnum.parse()?;
-            let oth_bigint = other.as_str();
-            if let Some(oth) = oth_bigint {
-                return Ok(bigint <= oth.parse()?);
+    fn le_g(&self, other: &Self) -> StdResult<bool> {
+        match (self, other) {
+            (Value::String(str_num), Value::String(oth)) => {
+                let big_num: Uint512 = str_num.parse()?;
+                let big_oth: Uint512 = oth.parse()?;
+                Ok(big_num <= big_oth)
             }
-        } else {
-            let num = self.as_u64();
-            let oth_num = other.as_u64();
-            if let (Some(n), Some(oth)) = (num, oth_num) {
-                return Ok(n <= oth);
-            }
-        };
-
-        Err(StdError::parse_err(
-            "number",
-            "Failed to parse to Uint512 and to u64",
-        ))
+            (Value::U64(n), Value::U64(o)) => Ok(n <= o),
+            (Value::U32(n), Value::U32(o)) => Ok(n <= o),
+            (Value::U16(n), Value::U16(o)) => Ok(n <= o),
+            (Value::U8(n), Value::U8(o)) => Ok(n <= o),
+            _ => Err(StdError::parse_err(
+                "number",
+                "Failed to parse to Uint512 and to u64",
+            )),
+        }
     }
 
-    fn bt(&self, other: &Self) -> StdResult<bool> {
-        if let Value::String(strnum) = self {
-            let bigint: Uint512 = strnum.parse()?;
-            let oth_bigint = other.as_str();
-            if let Some(oth) = oth_bigint {
-                return Ok(bigint > oth.parse()?);
+    fn bt_g(&self, other: &Self) -> StdResult<bool> {
+        match (self, other) {
+            (Value::String(str_num), Value::String(oth)) => {
+                let big_num: Uint512 = str_num.parse()?;
+                let big_oth: Uint512 = oth.parse()?;
+                Ok(big_num > big_oth)
             }
-        } else {
-            let num = self.as_u64();
-            let oth_num = other.as_u64();
-            if let (Some(n), Some(oth)) = (num, oth_num) {
-                return Ok(n > oth);
-            }
-        };
-
-        Err(StdError::parse_err(
-            "number",
-            "Failed to parse to Uint512 and to u64",
-        ))
+            (Value::U64(n), Value::U64(o)) => Ok(n > o),
+            (Value::U32(n), Value::U32(o)) => Ok(n > o),
+            (Value::U16(n), Value::U16(o)) => Ok(n > o),
+            (Value::U8(n), Value::U8(o)) => Ok(n > o),
+            _ => Err(StdError::parse_err(
+                "number",
+                "Failed to parse to Uint512 and to u64",
+            )),
+        }
     }
 
-    fn be(&self, other: &Self) -> StdResult<bool> {
-        if let Value::String(strnum) = self {
-            let bigint: Uint512 = strnum.parse()?;
-            let oth_bigint = other.as_str();
-            if let Some(oth) = oth_bigint {
-                return Ok(bigint >= oth.parse()?);
+    fn be_g(&self, other: &Self) -> StdResult<bool> {
+        match (self, other) {
+            (Value::String(str_num), Value::String(oth)) => {
+                let big_num: Uint512 = str_num.parse()?;
+                let big_oth: Uint512 = oth.parse()?;
+                Ok(big_num >= big_oth)
             }
-        } else {
-            let num = self.as_u64();
-            let oth_num = other.as_u64();
-            if let (Some(n), Some(oth)) = (num, oth_num) {
-                return Ok(n >= oth);
-            }
-        };
-
-        Err(StdError::parse_err(
-            "number",
-            "Failed to parse to Uint512 and to u64",
-        ))
+            (Value::U64(n), Value::U64(o)) => Ok(n >= o),
+            (Value::U32(n), Value::U32(o)) => Ok(n >= o),
+            (Value::U16(n), Value::U16(o)) => Ok(n >= o),
+            (Value::U8(n), Value::U8(o)) => Ok(n >= o),
+            _ => Err(StdError::parse_err(
+                "number",
+                "Failed to parse to Uint512 and to u64",
+            )),
+        }
     }
 
     fn equal(&self, other: &Self) -> bool {
@@ -116,136 +104,271 @@ impl ValueOrd for Value {
 #[cfg(test)]
 mod test {
     use cosmwasm_std::StdError;
-    use serde_json::Value;
 
     use super::ValueOrd;
 
     #[test]
-    fn test_lt() {
+    fn test_lt_g() {
         // less
-        assert!(Value::from(5_u64).lt(&Value::from(6_u64)).unwrap());
-        assert!(Value::from("5").lt(&Value::from("6")).unwrap());
+        assert!(serde_cw_value::to_value(5_u64)
+            .unwrap()
+            .lt_g(&serde_cw_value::to_value(6_u64).unwrap())
+            .unwrap());
+        assert!(serde_cw_value::to_value("5")
+            .unwrap()
+            .lt_g(&serde_cw_value::to_value("6").unwrap())
+            .unwrap());
         // equal
-        assert!(!Value::from(5_u64).lt(&Value::from(5_u64)).unwrap());
-        assert!(!Value::from("5").lt(&Value::from("5")).unwrap());
+        assert!(!serde_cw_value::to_value(5_u64)
+            .unwrap()
+            .lt_g(&serde_cw_value::to_value(5_u64).unwrap())
+            .unwrap());
+        assert!(!serde_cw_value::to_value("5")
+            .unwrap()
+            .lt_g(&serde_cw_value::to_value("5").unwrap())
+            .unwrap());
         // bigger than
-        assert!(!Value::from(42_u64).lt(&Value::from(8_u64)).unwrap());
-        assert!(!Value::from("42").lt(&Value::from("8")).unwrap());
+        assert!(!serde_cw_value::to_value(42_u64)
+            .unwrap()
+            .lt_g(&serde_cw_value::to_value(8_u64).unwrap())
+            .unwrap());
+        assert!(!serde_cw_value::to_value("42")
+            .unwrap()
+            .lt_g(&serde_cw_value::to_value("8").unwrap())
+            .unwrap());
     }
 
     #[test]
     fn test_lt_negative() {
-        let different_types = Value::from(5_u64).lt(&Value::from("6")).unwrap_err();
+        let different_types = serde_cw_value::to_value(5_u64)
+            .unwrap()
+            .lt_g(&serde_cw_value::to_value("6").unwrap())
+            .unwrap_err();
         assert!(matches!(different_types, StdError::ParseErr { .. }));
 
-        let different_types = Value::from("5").lt(&Value::from(6_u64)).unwrap_err();
+        let different_types = serde_cw_value::to_value("5")
+            .unwrap()
+            .lt_g(&serde_cw_value::to_value(6_u64).unwrap())
+            .unwrap_err();
         assert!(matches!(different_types, StdError::ParseErr { .. }));
 
-        let invalid_value = Value::from("foo").lt(&Value::from(6_u64)).unwrap_err();
-        assert!(matches!(invalid_value, StdError::GenericErr { .. }));
+        let invalid_value = serde_cw_value::to_value("foo")
+            .unwrap()
+            .lt_g(&serde_cw_value::to_value(6_u64).unwrap())
+            .unwrap_err();
+        assert!(matches!(invalid_value, StdError::ParseErr { .. }));
 
-        let invalid_value = Value::from("5").lt(&Value::from("bar")).unwrap_err();
+        let invalid_value = serde_cw_value::to_value("5")
+            .unwrap()
+            .lt_g(&serde_cw_value::to_value("bar").unwrap())
+            .unwrap_err();
         assert!(matches!(invalid_value, StdError::GenericErr { .. }));
     }
 
     #[test]
-    fn test_le() {
+    fn test_le_g() {
         // less
-        assert!(Value::from(5_u64).le(&Value::from(6_u64)).unwrap());
-        assert!(Value::from("5").le(&Value::from("6")).unwrap());
+        assert!(serde_cw_value::to_value(5_u64)
+            .unwrap()
+            .le_g(&serde_cw_value::to_value(6_u64).unwrap())
+            .unwrap());
+        assert!(serde_cw_value::to_value("5")
+            .unwrap()
+            .le_g(&serde_cw_value::to_value("6").unwrap())
+            .unwrap());
         // equal
-        assert!(Value::from(5_u64).le(&Value::from(5_u64)).unwrap());
-        assert!(Value::from("5").le(&Value::from("5")).unwrap());
+        assert!(serde_cw_value::to_value(5_u64)
+            .unwrap()
+            .le_g(&serde_cw_value::to_value(5_u64).unwrap())
+            .unwrap());
+        assert!(serde_cw_value::to_value("5")
+            .unwrap()
+            .le_g(&serde_cw_value::to_value("5").unwrap())
+            .unwrap());
         // bigger than
-        assert!(!Value::from(42_u64).le(&Value::from(8_u64)).unwrap());
-        assert!(!Value::from("42").le(&Value::from("8")).unwrap());
+        assert!(!serde_cw_value::to_value(42_u64)
+            .unwrap()
+            .le_g(&serde_cw_value::to_value(8_u64).unwrap())
+            .unwrap());
+        assert!(!serde_cw_value::to_value("42")
+            .unwrap()
+            .le_g(&serde_cw_value::to_value("8").unwrap())
+            .unwrap());
     }
 
     #[test]
     fn test_le_negative() {
-        let different_types = Value::from(5_u64).le(&Value::from("6")).unwrap_err();
+        let different_types = serde_cw_value::to_value(5_u64)
+            .unwrap()
+            .le_g(&serde_cw_value::to_value("6").unwrap())
+            .unwrap_err();
         assert!(matches!(different_types, StdError::ParseErr { .. }));
 
-        let different_types = Value::from("5").le(&Value::from(6_u64)).unwrap_err();
+        let different_types = serde_cw_value::to_value("5")
+            .unwrap()
+            .le_g(&serde_cw_value::to_value(6_u64).unwrap())
+            .unwrap_err();
         assert!(matches!(different_types, StdError::ParseErr { .. }));
 
-        let invalid_value = Value::from("foo").le(&Value::from(6_u64)).unwrap_err();
-        assert!(matches!(invalid_value, StdError::GenericErr { .. }));
+        let invalid_value = serde_cw_value::to_value("foo")
+            .unwrap()
+            .le_g(&serde_cw_value::to_value(6_u64).unwrap())
+            .unwrap_err();
+        assert!(matches!(invalid_value, StdError::ParseErr { .. }));
 
-        let invalid_value = Value::from("5").le(&Value::from("bar")).unwrap_err();
+        let invalid_value = serde_cw_value::to_value("5")
+            .unwrap()
+            .le_g(&serde_cw_value::to_value("bar").unwrap())
+            .unwrap_err();
         assert!(matches!(invalid_value, StdError::GenericErr { .. }));
     }
 
     #[test]
-    fn test_bt() {
+    fn test_bt_g() {
         // less
-        assert!(!Value::from(5_u64).bt(&Value::from(6_u64)).unwrap());
-        assert!(!Value::from("5").bt(&Value::from("6")).unwrap());
+        assert!(!serde_cw_value::to_value(5_u64)
+            .unwrap()
+            .bt_g(&serde_cw_value::to_value(6_u64).unwrap())
+            .unwrap());
+        assert!(!serde_cw_value::to_value("5")
+            .unwrap()
+            .bt_g(&serde_cw_value::to_value("6").unwrap())
+            .unwrap());
         // equal
-        assert!(!Value::from(5_u64).bt(&Value::from(5_u64)).unwrap());
-        assert!(!Value::from("5").bt(&Value::from("5")).unwrap());
+        assert!(!serde_cw_value::to_value(5_u64)
+            .unwrap()
+            .bt_g(&serde_cw_value::to_value(5_u64).unwrap())
+            .unwrap());
+        assert!(!serde_cw_value::to_value("5")
+            .unwrap()
+            .bt_g(&serde_cw_value::to_value("5").unwrap())
+            .unwrap());
         // bigger than
-        assert!(Value::from(42_u64).bt(&Value::from(8_u64)).unwrap());
-        assert!(Value::from("42").bt(&Value::from("8")).unwrap());
+        assert!(serde_cw_value::to_value(42_u64)
+            .unwrap()
+            .bt_g(&serde_cw_value::to_value(8_u64).unwrap())
+            .unwrap());
+        assert!(serde_cw_value::to_value("42")
+            .unwrap()
+            .bt_g(&serde_cw_value::to_value("8").unwrap())
+            .unwrap());
     }
 
     #[test]
     fn test_bt_negative() {
-        let different_types = Value::from(5_u64).bt(&Value::from("6")).unwrap_err();
+        let different_types = serde_cw_value::to_value(5_u64)
+            .unwrap()
+            .bt_g(&serde_cw_value::to_value("6").unwrap())
+            .unwrap_err();
         assert!(matches!(different_types, StdError::ParseErr { .. }));
 
-        let different_types = Value::from("5").bt(&Value::from(6_u64)).unwrap_err();
+        let different_types = serde_cw_value::to_value("5")
+            .unwrap()
+            .bt_g(&serde_cw_value::to_value(6_u64).unwrap())
+            .unwrap_err();
         assert!(matches!(different_types, StdError::ParseErr { .. }));
 
-        let invalid_value = Value::from("foo").bt(&Value::from(6_u64)).unwrap_err();
-        assert!(matches!(invalid_value, StdError::GenericErr { .. }));
+        let invalid_value = serde_cw_value::to_value("foo")
+            .unwrap()
+            .bt_g(&serde_cw_value::to_value(6_u64).unwrap())
+            .unwrap_err();
+        assert!(matches!(invalid_value, StdError::ParseErr { .. }));
 
-        let invalid_value = Value::from("5").bt(&Value::from("bar")).unwrap_err();
+        let invalid_value = serde_cw_value::to_value("5")
+            .unwrap()
+            .bt_g(&serde_cw_value::to_value("bar").unwrap())
+            .unwrap_err();
         assert!(matches!(invalid_value, StdError::GenericErr { .. }));
     }
 
     #[test]
-    fn test_be() {
+    fn test_be_g() {
         // less
-        assert!(!Value::from(5_u64).be(&Value::from(6_u64)).unwrap());
-        assert!(!Value::from("5").be(&Value::from("6")).unwrap());
+        assert!(!serde_cw_value::to_value(5_u64)
+            .unwrap()
+            .be_g(&serde_cw_value::to_value(6_u64).unwrap())
+            .unwrap());
+        assert!(!serde_cw_value::to_value("5")
+            .unwrap()
+            .be_g(&serde_cw_value::to_value("6").unwrap())
+            .unwrap());
         // equal
-        assert!(Value::from(5_u64).be(&Value::from(5_u64)).unwrap());
-        assert!(Value::from("5").be(&Value::from("5")).unwrap());
+        assert!(serde_cw_value::to_value(5_u64)
+            .unwrap()
+            .be_g(&serde_cw_value::to_value(5_u64).unwrap())
+            .unwrap());
+        assert!(serde_cw_value::to_value("5")
+            .unwrap()
+            .be_g(&serde_cw_value::to_value("5").unwrap())
+            .unwrap());
         // bigger than
-        assert!(Value::from(42_u64).be(&Value::from(8_u64)).unwrap());
-        assert!(Value::from("42").be(&Value::from("8")).unwrap());
+        assert!(serde_cw_value::to_value(42_u64)
+            .unwrap()
+            .be_g(&serde_cw_value::to_value(8_u64).unwrap())
+            .unwrap());
+        assert!(serde_cw_value::to_value("42")
+            .unwrap()
+            .be_g(&serde_cw_value::to_value("8").unwrap())
+            .unwrap());
     }
 
     #[test]
     fn test_be_negative() {
-        let different_types = Value::from(5_u64).be(&Value::from("6")).unwrap_err();
+        let different_types = serde_cw_value::to_value(5_u64)
+            .unwrap()
+            .be_g(&serde_cw_value::to_value("6").unwrap())
+            .unwrap_err();
         assert!(matches!(different_types, StdError::ParseErr { .. }));
 
-        let different_types = Value::from("5").be(&Value::from(6_u64)).unwrap_err();
+        let different_types = serde_cw_value::to_value("5")
+            .unwrap()
+            .be_g(&serde_cw_value::to_value(6_u64).unwrap())
+            .unwrap_err();
         assert!(matches!(different_types, StdError::ParseErr { .. }));
 
-        let invalid_value = Value::from("foo").be(&Value::from(6_u64)).unwrap_err();
-        assert!(matches!(invalid_value, StdError::GenericErr { .. }));
+        let invalid_value = serde_cw_value::to_value("foo")
+            .unwrap()
+            .be_g(&serde_cw_value::to_value(6_u64).unwrap())
+            .unwrap_err();
+        assert!(matches!(invalid_value, StdError::ParseErr { .. }));
 
-        let invalid_value = Value::from("5").be(&Value::from("bar")).unwrap_err();
+        let invalid_value = serde_cw_value::to_value("5")
+            .unwrap()
+            .be_g(&serde_cw_value::to_value("bar").unwrap())
+            .unwrap_err();
         assert!(matches!(invalid_value, StdError::GenericErr { .. }));
     }
 
     #[test]
     fn test_equal() {
         // less
-        assert!(!Value::from(5_u64).equal(&Value::from(6_u64)));
-        assert!(!Value::from("5").equal(&Value::from("6")));
+        assert!(!serde_cw_value::to_value(5_u64)
+            .unwrap()
+            .equal(&serde_cw_value::to_value(6_u64).unwrap()));
+        assert!(!serde_cw_value::to_value("5")
+            .unwrap()
+            .equal(&serde_cw_value::to_value("6").unwrap()));
         // equal
-        assert!(Value::from(5_u64).equal(&Value::from(5_u64)));
-        assert!(Value::from("5").equal(&Value::from("5")));
+        assert!(serde_cw_value::to_value(5_u64)
+            .unwrap()
+            .equal(&serde_cw_value::to_value(5_u64).unwrap()));
+        assert!(serde_cw_value::to_value("5")
+            .unwrap()
+            .equal(&serde_cw_value::to_value("5").unwrap()));
         // bigger than
-        assert!(!Value::from(42_u64).equal(&Value::from(8_u64)));
-        assert!(!Value::from("42").equal(&Value::from("8")));
+        assert!(!serde_cw_value::to_value(42_u64)
+            .unwrap()
+            .equal(&serde_cw_value::to_value(8_u64).unwrap()));
+        assert!(!serde_cw_value::to_value("42")
+            .unwrap()
+            .equal(&serde_cw_value::to_value("8").unwrap()));
 
         // Equal can match not only numbers
-        assert!(Value::from(r#"{"foo": "bar"}"#).equal(&Value::from(r#"{"foo": "bar"}"#)));
-        assert!(!Value::from(r#"{"foo": "bar"}"#).equal(&Value::from(r#"{"bar": "foo"}"#)));
+        assert!(serde_cw_value::to_value(r#"{"foo": "bar"}"#)
+            .unwrap()
+            .equal(&serde_cw_value::to_value(r#"{"foo": "bar"}"#).unwrap()));
+        assert!(!serde_cw_value::to_value(r#"{"foo": "bar"}"#)
+            .unwrap()
+            .equal(&serde_cw_value::to_value(r#"{"bar": "foo"}"#).unwrap()));
     }
 }

--- a/contracts/cw-rules/src/tests/generic.rs
+++ b/contracts/cw-rules/src/tests/generic.rs
@@ -95,11 +95,11 @@ fn test_generic() {
         .unwrap(),
         gets: vec![
             ValueIndex::Key("members".to_string()),
-            ValueIndex::Number(1),
+            ValueIndex::Index(1),
             ValueIndex::Key("weight".to_string()),
         ],
         ordering: ValueOrdering::UnitAbove,
-        value: json!(1),
+        value: to_binary(&1).unwrap(),
     };
     let binary = to_binary(&generic_query).unwrap();
     let msg = QueryMsg::QueryConstruct {
@@ -161,9 +161,9 @@ fn test_generic_json_repr() {
     .unwrap();
     let generic_query_json = json!({
         "msg": query_binary,
-        "gets": ["members", 1, "weight"],
+        "gets": [{"key": "members"}, {"index": 1}, {"key": "weight"}],
         "ordering": "unit_above",
-        "value": 1
+        "value": to_binary(&1).unwrap()
     });
     let binary: Binary = Binary(generic_query_json.to_string().into_bytes());
     let msg = QueryMsg::QueryConstruct {
@@ -220,7 +220,7 @@ fn test_generic_bigint() {
         msg: to_binary(&cw20::Cw20QueryMsg::TokenInfo {}).unwrap(),
         gets: vec![ValueIndex::Key("total_supply".to_string())],
         ordering: ValueOrdering::UnitAbove,
-        value: json!("2012"),
+        value: to_binary("2012").unwrap(),
     };
     // what we get here is :
     // pub struct TokenInfoResponse {

--- a/contracts/cw-rules/src/types.rs
+++ b/contracts/cw-rules/src/types.rs
@@ -31,20 +31,19 @@ pub mod generic_query {
     use super::*;
     use crate::helpers::ValueOrdering;
     use cosmwasm_std::Binary;
-    use serde_json::Value;
     #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
     pub struct GenericQuery {
         pub msg: Binary,
         pub gets: Vec<ValueIndex>,
 
         pub ordering: ValueOrdering,
-        pub value: Value,
+        pub value: Binary,
     }
 
     #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
-    #[serde(untagged)]
+    #[serde(rename_all = "snake_case")]
     pub enum ValueIndex {
         Key(String),
-        Number(u64),
+        Index(u64),
     }
 }


### PR DESCRIPTION
Pretty good explanation: https://medium.com/cosmwasm/debugging-floating-point-generation-in-rust-wasm-smart-contract-f47d833b5fba
TL;DR:
Don't use: 
1. [untagged](https://serde.rs/enum-representations.html#untagged) for cw
2. `serde_json::Value`, there is an alternative for cw: [serde-cw-value](https://github.com/CosmWasm/serde-cw-value)
3. TBH any of `serde_json` (exception is testing) , cw_std has deserializer: `cosmwasm_std::from_slice` and anything you gonna need for ser/de