### PR TITLE
Add scripts for local Juno chain

### DIFF
--- a/contracts/cw-croncat/scripts/README.md
+++ b/contracts/cw-croncat/scripts/README.md
@@ -1,0 +1,57 @@
+# Examples
+
+## Local setup
+
+**Warning**: running this script will remove any existing agent key pairs you have stored in `~/.croncatd/agents.json` as well as the `~./juno` which is used by your local `junod`.
+
+You will need `junod` which you can get installed by following these directions:
+https://docs.junonetwork.io/validators/getting-setup
+
+After following directions, you should be able to run:
+
+    junod version
+
+and see: `v9.0.0`
+
+Ensure you have a relatively clean set of keys for your local Juno chain. You can see a list of keys by running:
+
+    junod keys list
+
+and can delete them with:
+
+    junod keys delete <name>
+
+Run this script to remove old agent and Juno chain info, create new keys, deploy and instantiate the Croncat Manager contract, and add a simple payroll task that pays Alice and Bob a little bit of `stake` tokens every 3 blocks:
+
+    ./local_start.sh
+
+A `junod` process is running in the background now, and we can start our agent.
+
+Clone and run the Croncat Agent:
+
+```
+git clone https://github.com/CronCats/croncat-rs.git
+cd croncat-rs
+git checkout seed-phrase-flag
+cargo run generate-mnemonic --mnemonic="shove click bless section used eye able chaos welcome peasant base apart issue reduce sphere oven salmon glow distance strategy tortoise spot grunt area"
+cargo run register-agent
+cargo run go
+```
+
+In a separate tab you can see the balances by running:
+
+    ./local_balances.sh
+
+If you run the previous scripted repeatedly you'll see the simple, automated payroll is operational.
+
+To stop the local Juno chain, you may run:
+
+    ./local_stop.sh
+
+## Misc
+
+### Create a recurring task to send 1 testnet Juno to two addresses (TODO, really recurring?)
+    ./testnet_create_recurring_task.sh juno123contractaddress alice
+
+### Create staking task
+    ./testnet_create_staking_task.sh juno123contractaddress alice

--- a/contracts/cw-croncat/scripts/build.sh
+++ b/contracts/cw-croncat/scripts/build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Note: the below command has amd64 as the target, meaning M1 macs
+# Please use these directions if you're not on one:
+#   https://docs.cosmwasm.com/docs/1.0/getting-started/compile-contract#optimized-compilation
+docker run --rm -v "$(pwd)":/code \
+  --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target \
+  --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
+  --platform linux/amd64 \
+  cosmwasm/workspace-optimizer:0.12.7

--- a/contracts/cw-croncat/scripts/local_balances.sh
+++ b/contracts/cw-croncat/scripts/local_balances.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+echo "Showing balances for:"
+echo "validator"
+junod q bank balances $(junod keys show validator -a)
+echo "owner"
+junod q bank balances $(junod keys show owner -a)
+echo "agent"
+junod q bank balances $(junod keys show agent -a)
+echo "user"
+junod q bank balances $(junod keys show user -a)
+echo "alice"
+junod q bank balances $(junod keys show alice -a)
+echo "bob"
+junod q bank balances $(junod keys show bob -a)

--- a/contracts/cw-croncat/scripts/local_init_vars.sh
+++ b/contracts/cw-croncat/scripts/local_init_vars.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+NODE="--node http://localhost:26657"
+TXFLAG="--node http://localhost:26657 --chain-id croncat-0.0.1 --gas-prices 0.025stake --gas auto --gas-adjustment 1.3 --broadcast-mode block"

--- a/contracts/cw-croncat/scripts/local_start.sh
+++ b/contracts/cw-croncat/scripts/local_start.sh
@@ -45,6 +45,8 @@ FUND_RES=$(junod tx bank send $(junod keys show validator -a) $(junod keys show 
 junod tx bank send $(junod keys show validator -a) $(junod keys show agent -a) 600000000000stake --chain-id croncat-0.0.1 --sequence 2 -y
 junod tx bank send $(junod keys show validator -a) $(junod keys show user -a) 600000000000stake --chain-id croncat-0.0.1  --sequence 3 -y
 junod tx bank send $(junod keys show validator -a) $(junod keys show agent -a) 600000000000stake --chain-id croncat-0.0.1  --sequence 4 -y
+junod tx bank send $(junod keys show validator -a) $(junod keys show alice -a) 1stake --chain-id croncat-0.0.1  --sequence 5 -y
+junod tx bank send $(junod keys show validator -a) $(junod keys show bob -a) 1stake --chain-id croncat-0.0.1  --sequence 6 -y
 echo "Fund owner result: $FUND_RES"
 sleep 1
 

--- a/contracts/cw-croncat/scripts/local_start.sh
+++ b/contracts/cw-croncat/scripts/local_start.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+
+# Destroy local juno
+rm -rf ~/.juno
+# Destroy local Croncat agent settings, including agent(s) keypairs
+rm -rf ~/.croncatd
+
+cd "$(dirname "$0")"
+. ./local_init_vars.sh
+
+junod init croncat --chain-id croncat-0.0.1 --overwrite
+sleep 2
+
+# Thanks to
+#   Ethan Frey https://github.com/CosmWasm/wasmd/commit/810c05bbcadf903b687f1365f3927cb65511dc1f#diff-d37e3d2a27ee91db29137c81077c90b138427843e8f21e78f0c6e7645803ad1cR14
+#   and Jorge Hernandez's message here: https://discord.com/channels/737637324434833438/737640672680607764/1019038743610523730
+sed -i '' -e 's/"time_iota_ms": "1000"/"time_iota_ms": "10"/' "$HOME"/.juno/config/genesis.json
+sed -i '' -e 's/timeout_commit = "5s"/timeout_commit = "1s"/' "$HOME"/.juno/config/config.toml
+sed -i '' -e 's/timeout_propose = "5s"/timeout_propose = "1s"/' "$HOME"/.juno/config/config.toml
+
+VALIDATOR_SEED_PHRASE="before ice gravity winner mystery noble rug science barely patrol snake foot jelly buddy olympic remove addict health whale better purse pen vacant attract"
+junod keys show validator 2> /dev/null || echo $VALIDATOR_SEED_PHRASE | junod keys add validator --recover
+OWNER_SEED_PHRASE="bind desert siege network dog any fix carbon evidence install any eternal front hidden you report still basic nothing market mask youth early cigar"
+junod keys show owner 2> /dev/null || echo $OWNER_SEED_PHRASE | junod keys add owner --recover
+AGENT_SEED_PHRASE="shove click bless section used eye able chaos welcome peasant base apart issue reduce sphere oven salmon glow distance strategy tortoise spot grunt area"
+junod keys show agent 2> /dev/null || echo $AGENT_SEED_PHRASE | junod keys add agent --recover # && croncatd generate-mnemonic --mnemonic $AGENT_SEED_PHRASE
+USER_SEED_PHRASE="gas silly unlock shy face bless pave fancy hamster snap coast scare kingdom reopen deny make pride sea shine night curve source cram bunker"
+junod keys show user 2> /dev/null || echo $USER_SEED_PHRASE | junod keys add user --recover
+ALICE_SEED_PHRASE="fix salute raise you copper outer illness mosquito version cave broccoli stick limit glad typical harsh retreat rebuild unhappy settle guilt churn slam chalk"
+junod keys show alice 2> /dev/null || echo $ALICE_SEED_PHRASE | junod keys add alice --recover
+BOB_SEED_PHRASE="book obey ensure swarm ill drink blind process trend certain kind enhance motion world flame portion select crater fruit tuition brick earth fee weird"
+junod keys show bob 2> /dev/null || echo $BOB_SEED_PHRASE | junod keys add bob --recover
+
+junod add-genesis-account $(junod keys show validator -a) 10000000000000000000000000stake
+junod gentx validator 1000000000000000stake --chain-id croncat-0.0.1 --chain-id croncat-0.0.1
+junod collect-gentxs
+sleep 1
+
+# Start the Juno chain, making sure we have gRPC
+junod start --grpc.address "127.0.0.1:9090" >/dev/null 2>&1 < /dev/null &
+sleep 3
+
+# Send funds from the validator to necessary parties
+FUND_RES=$(junod tx bank send $(junod keys show validator -a) $(junod keys show owner -a) 600000000000stake --chain-id croncat-0.0.1 -y)
+junod tx bank send $(junod keys show validator -a) $(junod keys show agent -a) 600000000000stake --chain-id croncat-0.0.1 --sequence 2 -y
+junod tx bank send $(junod keys show validator -a) $(junod keys show user -a) 600000000000stake --chain-id croncat-0.0.1  --sequence 3 -y
+junod tx bank send $(junod keys show validator -a) $(junod keys show agent -a) 600000000000stake --chain-id croncat-0.0.1  --sequence 4 -y
+echo "Fund owner result: $FUND_RES"
+sleep 1
+
+# Upload the Croncat Manager contract
+RES=$(junod tx wasm store ../../../artifacts/cw_croncat.wasm --from owner --node http://localhost:26657 --chain-id croncat-0.0.1 --gas-prices 0.025stake --gas auto --gas-adjustment 1.3 --broadcast-mode block -y --output json -b block)
+CODE_ID=$(echo $RES | jq -r '.logs[0].events[-1].attributes[0].value')
+echo "Code ID: $CODE_ID"
+
+# Instantiate
+INIT='{"denom":"stake"}'
+junod tx wasm instantiate $CODE_ID "$INIT" --from owner --label "croncat" $TXFLAG --no-admin -y
+CONTRACT=$(junod query wasm list-contract-by-code $CODE_ID $NODE --output json | jq -r '.contracts[-1]')
+echo "Croncat Manager contract address: $CONTRACT"
+
+echo "Creating simple payroll"
+# Create recurring payroll to alice and bob
+SIMPLE_PAYROLL='{
+  "create_task": {
+    "task": {
+      "interval": {
+        "Block": 3
+      },
+      "boundary": null,
+      "cw20_coins": [],
+      "stop_on_fail": false,
+      "actions": [
+        {
+          "msg": {
+            "bank": {
+              "send": {
+                "amount": [
+                  {
+                    "amount": "6",
+                    "denom": "stake"
+                  }
+                ],
+                "to_address": "'$(junod keys show alice -a)'"
+              }
+            }
+          }
+        },
+        {
+          "msg": {
+            "bank": {
+              "send": {
+                "amount": [
+                  {
+                    "amount": "1",
+                    "denom": "stake"
+                  }
+                ],
+                "to_address": "'$(junod keys show bob -a)'"
+              }
+            }
+          }
+        }
+      ],
+      "rules": []
+    }
+  }
+}'
+junod tx wasm execute $CONTRACT "$SIMPLE_PAYROLL" --amount 1000000000stake --from user $TXFLAG -y
+echo "Done creating simple payroll"

--- a/contracts/cw-croncat/scripts/local_stop.sh
+++ b/contracts/cw-croncat/scripts/local_stop.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+kill -9 $(ps aux | grep juno | grep -v grep | awk -v x=2 '{print $x}')


### PR DESCRIPTION
I've created some scripts in `cw-croncat/contracts/cw-croncat/scripts` that are prefixed with `local_`. These will help local development so we can test things without relying on Juno testnet gRPC, RPC, websockets, and faucets being up.

Please see the `REAMD.md` file in that same directory for instructions (that are ever-changing) on how to demonstrate a full, simple payroll being executed.