### PR TITLE
Add method for checking and deleting bad agents

### DIFF
--- a/contracts/cw-croncat/src/agent.rs
+++ b/contracts/cw-croncat/src/agent.rs
@@ -34,7 +34,7 @@ impl<'a> CwCroncat<'a> {
             payable_account_id: a.payable_account_id,
             balance: a.balance,
             total_tasks_executed: a.total_tasks_executed,
-            last_missed_slot: a.last_missed_slot,
+            last_executed_slot: a.last_executed_slot,
             register_start: a.register_start,
         };
 
@@ -190,7 +190,7 @@ impl<'a> CwCroncat<'a> {
                             payable_account_id: payable_id,
                             balance: GenericBalance::default(),
                             total_tasks_executed: 0,
-                            last_missed_slot: 0,
+                            last_executed_slot: env.block.height,
                             // REF: https://github.com/CosmWasm/cosmwasm/blob/main/packages/std/src/types.rs#L57
                             register_start: env.block.time,
                         })

--- a/contracts/cw-croncat/src/agent.rs
+++ b/contracts/cw-croncat/src/agent.rs
@@ -246,11 +246,11 @@ impl<'a> CwCroncat<'a> {
     pub(crate) fn withdraw_balances(
         &self,
         storage: &mut dyn Storage,
-        info: MessageInfo,
+        agent_id: &Addr,
     ) -> Result<Vec<SubMsg>, ContractError> {
         let mut agent = self
             .agents
-            .may_load(storage, &info.sender)?
+            .may_load(storage, agent_id)?
             .ok_or(AgentNotRegistered {})?;
 
         // This will send all token balances to Agent
@@ -260,7 +260,7 @@ impl<'a> CwCroncat<'a> {
         config
             .available_balance
             .checked_sub_native(&balances.native)?;
-        self.agents.save(storage, &info.sender, &agent)?;
+        self.agents.save(storage, agent_id, &agent)?;
         self.config.save(storage, &config)?;
 
         Ok(messages)
@@ -270,14 +270,13 @@ impl<'a> CwCroncat<'a> {
     pub fn withdraw_agent_balance(
         &self,
         deps: DepsMut,
-        info: MessageInfo,
-        _env: Env,
+        agent_id: &Addr,
     ) -> Result<Response, ContractError> {
-        let messages = self.withdraw_balances(deps.storage, info.clone())?;
+        let messages = self.withdraw_balances(deps.storage, agent_id)?;
 
         Ok(Response::new()
             .add_attribute("method", "withdraw_agent_balance")
-            .add_attribute("account_id", info.sender)
+            .add_attribute("account_id", agent_id)
             .add_submessages(messages))
     }
 
@@ -350,43 +349,40 @@ impl<'a> CwCroncat<'a> {
     /// Withdraws all reward balances to the agent payable account id.
     pub fn unregister_agent(
         &self,
-        deps: DepsMut,
-        info: MessageInfo,
-        _env: Env,
+        storage: &mut dyn Storage,
+        agent_id: &Addr,
     ) -> Result<Response, ContractError> {
         // Get withdraw messages, if any
         // NOTE: Since this also checks if agent exists, safe to not have redundant logic
-        let messages = self.withdraw_balances(deps.storage, info.clone())?;
-        let agent_id = info.sender;
-        self.agents.remove(deps.storage, &agent_id);
+        let messages = self.withdraw_balances(storage, agent_id)?;
+        self.agents.remove(storage, agent_id);
 
         // Remove from the list of active agents if the agent in this list
         let mut active_agents: Vec<Addr> = self
             .agent_active_queue
-            .may_load(deps.storage)?
+            .may_load(storage)?
             .unwrap_or_default();
-        if let Some(index) = active_agents.iter().position(|addr| *addr == agent_id) {
+        if let Some(index) = active_agents.iter().position(|addr| *addr == *agent_id) {
             //Notify the balancer agent has been removed, to rebalance itself
             self.balancer.on_agent_unregister(
-                deps.storage,
+                storage,
                 &self.config,
                 &self.agent_active_queue,
                 agent_id.clone(),
             );
             active_agents.remove(index);
 
-            self.agent_active_queue.save(deps.storage, &active_agents)?;
+            self.agent_active_queue.save(storage, &active_agents)?;
         } else {
             // Agent can't be both in active and pending vector
             // Remove from the pending queue
             let mut pending_agents: Vec<Addr> = self
                 .agent_pending_queue
-                .may_load(deps.storage)?
+                .may_load(storage)?
                 .unwrap_or_default();
-            if let Some(index) = pending_agents.iter().position(|addr| *addr == agent_id) {
+            if let Some(index) = pending_agents.iter().position(|addr| addr == agent_id) {
                 pending_agents.remove(index);
-                self.agent_pending_queue
-                    .save(deps.storage, &pending_agents)?;
+                self.agent_pending_queue.save(storage, &pending_agents)?;
             }
         }
 

--- a/contracts/cw-croncat/src/contract.rs
+++ b/contracts/cw-croncat/src/contract.rs
@@ -135,8 +135,8 @@ impl<'a> CwCroncat<'a> {
             ExecuteMsg::UpdateAgent { payable_account_id } => {
                 self.update_agent(deps, info, env, payable_account_id)
             }
-            ExecuteMsg::UnregisterAgent {} => self.unregister_agent(deps, info, env),
-            ExecuteMsg::WithdrawReward {} => self.withdraw_agent_balance(deps, info, env),
+            ExecuteMsg::UnregisterAgent {} => self.unregister_agent(deps.storage, &info.sender),
+            ExecuteMsg::WithdrawReward {} => self.withdraw_agent_balance(deps, &info.sender),
             ExecuteMsg::CheckInAgent {} => self.accept_nomination_agent(deps, info, env),
 
             ExecuteMsg::CreateTask { task } => self.create_task(deps, info, env, task),
@@ -156,6 +156,7 @@ impl<'a> CwCroncat<'a> {
             ExecuteMsg::WithdrawWalletBalance {
                 cw20_amounts: cw20_balances,
             } => self.withdraw_wallet_balances(deps, info, cw20_balances),
+            ExecuteMsg::Tick {} => self.tick(deps, env),
         }
     }
 

--- a/contracts/cw-croncat/src/tests/agent.rs
+++ b/contracts/cw-croncat/src/tests/agent.rs
@@ -393,7 +393,7 @@ fn register_agent() {
     );
     assert_eq!(GenericBalance::default(), agent_info.balance);
     assert_eq!(0, agent_info.total_tasks_executed);
-    assert_eq!(0, agent_info.last_missed_slot);
+    assert_eq!(0, agent_info.last_executed_slot);
     assert_eq!(blk_time, agent_info.register_start);
 
     // test fail if try to re-register

--- a/contracts/cw-croncat/src/tests/agent.rs
+++ b/contracts/cw-croncat/src/tests/agent.rs
@@ -393,7 +393,7 @@ fn register_agent() {
     );
     assert_eq!(GenericBalance::default(), agent_info.balance);
     assert_eq!(0, agent_info.total_tasks_executed);
-    assert_eq!(0, agent_info.last_executed_slot);
+    assert_eq!(12345, agent_info.last_executed_slot);
     assert_eq!(blk_time, agent_info.register_start);
 
     // test fail if try to re-register

--- a/contracts/cw-croncat/src/tests/helpers.rs
+++ b/contracts/cw-croncat/src/tests/helpers.rs
@@ -170,6 +170,12 @@ pub fn add_one_duration_of_time(block: &mut BlockInfo) {
     block.height += 1;
 }
 
+pub fn add_1000_blocks(block: &mut BlockInfo) {
+    // block.time = block.time.plus_seconds(360);
+    block.time = block.time.plus_seconds(10);
+    block.height += 1000;
+}
+
 pub fn default_task() -> Task {
     Task {
         owner_id: Addr::unchecked("bob"),

--- a/packages/cw-croncat-core/schema/croncat.json
+++ b/packages/cw-croncat-core/schema/croncat.json
@@ -212,7 +212,7 @@
       "type": "object",
       "required": [
         "balance",
-        "last_missed_slot",
+        "last_executed_slot",
         "payable_account_id",
         "register_start",
         "total_tasks_executed"
@@ -221,7 +221,7 @@
         "balance": {
           "$ref": "#/definitions/GenericBalance"
         },
-        "last_missed_slot": {
+        "last_executed_slot": {
           "type": "integer",
           "format": "uint64",
           "minimum": 0.0
@@ -243,7 +243,7 @@
       "type": "object",
       "required": [
         "balance",
-        "last_missed_slot",
+        "last_executed_slot",
         "payable_account_id",
         "register_start",
         "status",
@@ -253,7 +253,7 @@
         "balance": {
           "$ref": "#/definitions/GenericBalance"
         },
-        "last_missed_slot": {
+        "last_executed_slot": {
           "type": "integer",
           "format": "uint64",
           "minimum": 0.0

--- a/packages/cw-croncat-core/schema/execute_msg.json
+++ b/packages/cw-croncat-core/schema/execute_msg.json
@@ -321,6 +321,18 @@
         }
       },
       "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "tick"
+      ],
+      "properties": {
+        "tick": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false
     }
   ],
   "definitions": {

--- a/packages/cw-croncat-core/schema/get_agent_response.json
+++ b/packages/cw-croncat-core/schema/get_agent_response.json
@@ -18,7 +18,7 @@
       "type": "object",
       "required": [
         "balance",
-        "last_missed_slot",
+        "last_executed_slot",
         "payable_account_id",
         "register_start",
         "status",
@@ -28,7 +28,7 @@
         "balance": {
           "$ref": "#/definitions/GenericBalance"
         },
-        "last_missed_slot": {
+        "last_executed_slot": {
           "type": "integer",
           "format": "uint64",
           "minimum": 0.0

--- a/packages/cw-croncat-core/src/msg.rs
+++ b/packages/cw-croncat-core/src/msg.rs
@@ -113,6 +113,7 @@ pub enum ExecuteMsg {
     WithdrawWalletBalance {
         cw20_amounts: Vec<Cw20Coin>,
     },
+    Tick {},
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/packages/cw-croncat-core/src/tests/msg.rs
+++ b/packages/cw-croncat-core/src/tests/msg.rs
@@ -26,7 +26,7 @@ fn everything_can_be_de_serialized() {
         payable_account_id: Addr::unchecked("test"),
         balance: generic_balance.clone(),
         total_tasks_executed: 0,
-        last_missed_slot: 3,
+        last_executed_slot: 3,
         register_start: Timestamp::from_nanos(5),
     }
     .into();
@@ -122,7 +122,7 @@ fn everything_can_be_de_serialized() {
         payable_account_id: Addr::unchecked("bob"),
         balance: generic_balance.clone(),
         total_tasks_executed: 2,
-        last_missed_slot: 2,
+        last_executed_slot: 2,
         register_start: Timestamp::from_nanos(5),
     })
     .into();

--- a/packages/cw-croncat-core/src/types.rs
+++ b/packages/cw-croncat-core/src/types.rs
@@ -46,11 +46,9 @@ pub struct Agent {
     // stats
     pub total_tasks_executed: u64,
 
-    // Holds slot number of a missed slot.
-    // If other agents see an agent miss a slot, they store the missed slot number.
-    // If agent does a task later, this number is reset to zero.
-    // Example data: 1633890060000000000 or 0
-    pub last_missed_slot: u64,
+    // Holds slot number of the last slot when agent called proxy_call.
+    // If agent does a task, this number is set to the current block.
+    pub last_executed_slot: u64,
 
     // Timestamp of when agent first registered
     // Useful for rewarding agents for their patience while they are pending and operating service
@@ -66,7 +64,7 @@ pub struct AgentResponse {
     pub payable_account_id: Addr,
     pub balance: GenericBalance,
     pub total_tasks_executed: u64,
-    pub last_missed_slot: u64,
+    pub last_executed_slot: u64,
     pub register_start: Timestamp,
 }
 

--- a/types/build/contract/CwCroncat.client.js
+++ b/types/build/contract/CwCroncat.client.js
@@ -243,6 +243,11 @@ class CwCroncatClient extends CwCroncatQueryClient {
                 }
             }, fee, memo, funds);
         });
+        this.tick = (fee = "auto", memo, funds) => __awaiter(this, void 0, void 0, function* () {
+            return yield this.client.execute(this.sender, this.contractAddress, {
+                tick: {}
+            }, fee, memo, funds);
+        });
         this.client = client;
         this.sender = sender;
         this.contractAddress = contractAddress;
@@ -260,6 +265,7 @@ class CwCroncatClient extends CwCroncatQueryClient {
         this.proxyCall = this.proxyCall.bind(this);
         this.receive = this.receive.bind(this);
         this.withdrawWalletBalance = this.withdrawWalletBalance.bind(this);
+        this.tick = this.tick.bind(this);
     }
 }
 exports.CwCroncatClient = CwCroncatClient;

--- a/types/contract/CwCroncat.client.ts
+++ b/types/contract/CwCroncat.client.ts
@@ -333,6 +333,7 @@ export interface CwCroncatInterface extends CwCroncatReadOnlyInterface {
   }: {
     cw20Amounts: Cw20Coin[];
   }, fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
+  tick: (fee?: number | StdFee | "auto", memo?: string, funds?: Coin[]) => Promise<ExecuteResult>;
 }
 export class CwCroncatClient extends CwCroncatQueryClient implements CwCroncatInterface {
   client: SigningCosmWasmClient;
@@ -358,6 +359,7 @@ export class CwCroncatClient extends CwCroncatQueryClient implements CwCroncatIn
     this.proxyCall = this.proxyCall.bind(this);
     this.receive = this.receive.bind(this);
     this.withdrawWalletBalance = this.withdrawWalletBalance.bind(this);
+    this.tick = this.tick.bind(this);
   }
 
   updateSettings = async ({
@@ -527,6 +529,11 @@ export class CwCroncatClient extends CwCroncatQueryClient implements CwCroncatIn
       withdraw_wallet_balance: {
         cw20_amounts: cw20Amounts
       }
+    }, fee, memo, funds);
+  };
+  tick = async (fee: number | StdFee | "auto" = "auto", memo?: string, funds?: Coin[]): Promise<ExecuteResult> => {
+    return await this.client.execute(this.sender, this.contractAddress, {
+      tick: {}
     }, fee, memo, funds);
   };
 }

--- a/types/contract/CwCroncat.types.ts
+++ b/types/contract/CwCroncat.types.ts
@@ -201,7 +201,7 @@ export interface Croncat {
 }
 export interface Agent {
   balance: GenericBalance;
-  last_missed_slot: number;
+  last_executed_slot: number;
   payable_account_id: Addr;
   register_start: Timestamp;
   total_tasks_executed: number;
@@ -250,7 +250,7 @@ export interface GetAgentIdsResponse {
 }
 export interface AgentResponse {
   balance: GenericBalance;
-  last_missed_slot: number;
+  last_executed_slot: number;
   payable_account_id: Addr;
   register_start: Timestamp;
   status: AgentStatus;
@@ -437,6 +437,10 @@ export type ExecuteMsg = {
 } | {
   withdraw_wallet_balance: {
     cw20_amounts: Cw20Coin[];
+    [k: string]: unknown;
+  };
+} | {
+  tick: {
     [k: string]: unknown;
   };
 };


### PR DESCRIPTION
Close #124

- added `last_executed_slot` for an agent, it is updated after every successful proxy call and stores this block number
- new method `Tick` unregisters agents which didn't act more than `cfg.agents_eject_threshold * cfg.slot_granularity` blocks

Also just noticed that in near implementation it's not allowed to delete the last agent, should we do the same here?