### PR TITLE
Fix manifests and bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -650,7 +650,7 @@ dependencies = [
 
 [[package]]
 name = "cw-croncat-core"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -782,7 +782,7 @@ dependencies = [
 
 [[package]]
 name = "cw-rules-core"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/contracts/cw-croncat/src/manager.rs
+++ b/contracts/cw-croncat/src/manager.rs
@@ -464,7 +464,10 @@ impl<'a> CwCroncat<'a> {
            //If Send and reccuring task increment withdrawn funds so contract doesnt get drained
         let transferred_bank_tokens = msg.transferred_bank_tokens();
         let task_to_finilize = task;
-        if task_to_finilize.contains_send_msg() && task_to_finilize.is_recurring() {
+        if task_to_finilize.contains_send_msg()
+            && task_to_finilize.is_recurring()
+            && !transferred_bank_tokens.is_empty()
+        {
             task_to_finilize
                 .funds_withdrawn_recurring
                 .saturating_add(transferred_bank_tokens[0].amount);

--- a/packages/cw-croncat-core/Cargo.toml
+++ b/packages/cw-croncat-core/Cargo.toml
@@ -14,7 +14,7 @@ optimize = """docker run --rm -v "$(pwd)":/code \
 
 [dependencies]
 cosmwasm-std = { version = "1.0.0", features = ["staking", "stargate"] }
-cw-rules-core = { version = "0.1.1" }
+cw-rules-core = { version = "0.1.1", path = "../cw-rules-core" }
 cosmwasm-storage = { version = "1.0.0" }
 cw-storage-plus = "0.13"
 cron_schedule = "0.2.2"

--- a/packages/cw-rules-core/Cargo.toml
+++ b/packages/cw-rules-core/Cargo.toml
@@ -14,7 +14,7 @@ cosmwasm-std = { version = "1.0.0", features = ["staking", "stargate"] }
 serde-cw-value = "0.7.0"
 # For some reason it tries to deploy cw_core here
 # voting = { version = "0.2.0", default-features = false, git = "https://github.com/DA0-DA0/dao-contracts" }
-generic-query = { version = "0.1.0" }
+generic-query = { version = "0.1.0", path = "../generic-query" }
 cw20 = { version = "0.13" }
 
 [dev-dependencies]


### PR DESCRIPTION
We have a bug that we saw yesterday when trying to use CronCat live.

Also, after reading this I understand we can add the path to the manifest
https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#multiple-locations