### PR TITLE
Remove task with rules when complete

### DIFF
--- a/contracts/cw-croncat/src/manager.rs
+++ b/contracts/cw-croncat/src/manager.rs
@@ -310,7 +310,6 @@ impl<'a> CwCroncat<'a> {
             || task.verify_enough_balances(false).is_err()
             // If the next interval comes back 0, then this task should not schedule again
             || next_id == 0
-            || task.with_rules()
         // proxy_call_with_rules makes it fail if rules aren't met
         {
             // Process task exit, if no future task can execute

--- a/contracts/cw-croncat/src/manager.rs
+++ b/contracts/cw-croncat/src/manager.rs
@@ -310,7 +310,8 @@ impl<'a> CwCroncat<'a> {
             || task.verify_enough_balances(false).is_err()
             // If the next interval comes back 0, then this task should not schedule again
             || next_id == 0
-            || task.with_rules() // proxy_call_with_rules makes it fail if rules aren't met
+            || task.with_rules()
+        // proxy_call_with_rules makes it fail if rules aren't met
         {
             // Process task exit, if no future task can execute
             // Task has been removed, complete and rebalance internal balancer

--- a/contracts/cw-croncat/src/manager.rs
+++ b/contracts/cw-croncat/src/manager.rs
@@ -310,6 +310,7 @@ impl<'a> CwCroncat<'a> {
             || task.verify_enough_balances(false).is_err()
             // If the next interval comes back 0, then this task should not schedule again
             || next_id == 0
+            || task.with_rules() // proxy_call_with_rules makes it fail if rules aren't met
         {
             // Process task exit, if no future task can execute
             // Task has been removed, complete and rebalance internal balancer

--- a/contracts/cw-croncat/src/tests/agent.rs
+++ b/contracts/cw-croncat/src/tests/agent.rs
@@ -916,7 +916,6 @@ fn test_query_get_agent_tasks() {
     query_task_res = app
         .wrap()
         .query_wasm_smart(contract_addr.clone(), &msg_agent_tasks);
-    println!("aloha query_task_res {:?}", query_task_res);
     assert_eq!(
         query_task_res.unwrap_err(),
         cosmwasm_std::StdError::GenericErr {

--- a/contracts/cw-croncat/src/tests/manager.rs
+++ b/contracts/cw-croncat/src/tests/manager.rs
@@ -1771,7 +1771,6 @@ fn test_reschedule_task_with_rule() {
             &[],
         )
         .unwrap();
-
     assert!(res.events.iter().any(|ev| ev
         .attributes
         .iter()
@@ -1780,18 +1779,6 @@ fn test_reschedule_task_with_rule() {
         .attributes
         .iter()
         .any(|attr| attr.key == "method" && attr.value == "proxy_callback")));
-
-    let tasks_with_rules: Vec<TaskWithRulesResponse> = app
-        .wrap()
-        .query_wasm_smart(
-            contract_addr.clone(),
-            &QueryMsg::GetTasksWithRules {
-                from_index: None,
-                limit: None,
-            },
-        )
-        .unwrap();
-    assert_eq!(tasks_with_rules.len(), 1);
 
     // Shouldn't affect tasks without rules
     let tasks_response: Vec<TaskResponse> = app
@@ -1805,24 +1792,6 @@ fn test_reschedule_task_with_rule() {
         )
         .unwrap();
     assert!(tasks_response.is_empty());
-    let res = app
-        .execute_contract(
-            Addr::unchecked(AGENT0),
-            contract_addr.clone(),
-            &ExecuteMsg::ProxyCall {
-                task_hash: Some(String::from(task_hash)),
-            },
-            &[],
-        )
-        .unwrap();
-    assert!(res.events.iter().any(|ev| ev
-        .attributes
-        .iter()
-        .any(|attr| attr.key == "task_hash" && attr.value == task_hash)));
-    assert!(res.events.iter().any(|ev| ev
-        .attributes
-        .iter()
-        .any(|attr| attr.key == "method" && attr.value == "proxy_callback")));
 
     let tasks_with_rules: Vec<TaskWithRulesResponse> = app
         .wrap()

--- a/contracts/cw-croncat/src/tests/manager.rs
+++ b/contracts/cw-croncat/src/tests/manager.rs
@@ -1713,7 +1713,7 @@ fn test_reschedule_task_with_rule() {
         },
     };
 
-    let attached_balance = 150058;
+    let attached_balance = 50058;
     app.execute_contract(
         Addr::unchecked(ADMIN),
         contract_addr.clone(),
@@ -1793,6 +1793,19 @@ fn test_reschedule_task_with_rule() {
         .unwrap();
     assert!(tasks_response.is_empty());
 
+    // Run it a bunch of times successfully, until it's removed because the balance falls too low
+    for _ in 1..8 {
+        assert!(app
+            .execute_contract(
+                Addr::unchecked(AGENT0),
+                contract_addr.clone(),
+                &ExecuteMsg::ProxyCall {
+                    task_hash: Some(String::from(task_hash)),
+                },
+                &[],
+            ).is_ok());
+    }
+
     let tasks_with_rules: Vec<TaskWithRulesResponse> = app
         .wrap()
         .query_wasm_smart(
@@ -1803,7 +1816,6 @@ fn test_reschedule_task_with_rule() {
             },
         )
         .unwrap();
-    println!("tasks_with_rules later {:#?}", tasks_with_rules);
     assert!(tasks_with_rules.is_empty());
 }
 


### PR DESCRIPTION
It appears that we are not removing tasks with rules once they successfully complete.

Basically you call `proxy_call` with a task hash, which will check using the querier (you can search for `deps.querier.query_wasm_smart` in `proxy_call_with_rules`) and fail if the rules aren't met. If the rules _are_ met, it'll go the `proxy_callback` and inside there is a loaded conditional that looked like this:

```rs
if task.interval == Interval::Once
    || (task.stop_on_fail && queue_item.failed)
    || task.verify_enough_balances(false).is_err()
    // If the next interval comes back 0, then this task should not schedule again
    || next_id == 0
```

But those don't account for tasks with rules, so I added the condition.

I saw a test breaking so dove deeper into it and see that it was assuming a few things that didn't make sense to me. (I could be wrong, of course, hence reviewers)) )
