### PR TITLE
Due to return macros, use allow unused_imports in a couple places

### DIFF
--- a/contracts/mod-balances/src/msg.rs
+++ b/contracts/mod-balances/src/msg.rs
@@ -1,5 +1,6 @@
 use crate::types::HasBalanceComparator;
 use cosmwasm_schema::{cw_serde, QueryResponses};
+#[allow(unused_imports)]
 use mod_sdk::types::QueryResponse;
 
 #[cw_serde]

--- a/contracts/mod-balances/src/msg.rs
+++ b/contracts/mod-balances/src/msg.rs
@@ -1,7 +1,5 @@
 use crate::types::HasBalanceComparator;
 use cosmwasm_schema::{cw_serde, QueryResponses};
-#[allow(unused_imports)]
-use mod_sdk::types::QueryResponse;
 
 #[cw_serde]
 pub struct InstantiateMsg {}
@@ -13,15 +11,15 @@ pub enum ExecuteMsg {}
 #[derive(QueryResponses)]
 pub enum QueryMsg {
     /// Get native `address` balance with specific `denom`
-    #[returns(QueryResponse)]
+    #[returns(mod_sdk::types::QueryResponse)]
     GetBalance { address: String, denom: String },
     /// Get cw20 balance by specific cw20 contract address
-    #[returns(QueryResponse)]
+    #[returns(mod_sdk::types::QueryResponse)]
     GetCw20Balance {
         cw20_contract: String,
         address: String,
     },
     /// Compare balance of `address` (native or cw20) with `required_balance`
-    #[returns(QueryResponse)]
+    #[returns(mod_sdk::types::QueryResponse)]
     HasBalanceComparator(HasBalanceComparator),
 }

--- a/contracts/mod-dao/src/msg.rs
+++ b/contracts/mod-dao/src/msg.rs
@@ -1,4 +1,5 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
+#[allow(unused_imports)]
 use mod_sdk::types::QueryResponse;
 
 use crate::types::ProposalStatusMatches;

--- a/contracts/mod-dao/src/msg.rs
+++ b/contracts/mod-dao/src/msg.rs
@@ -1,6 +1,4 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
-#[allow(unused_imports)]
-use mod_sdk::types::QueryResponse;
 
 use crate::types::ProposalStatusMatches;
 
@@ -14,18 +12,18 @@ pub enum ExecuteMsg {}
 #[derive(QueryResponses)]
 pub enum QueryMsg {
     // Query proposal status and compare it to pre-defined status
-    #[returns(QueryResponse)]
+    #[returns(mod_sdk::types::QueryResponse)]
     ProposalStatusMatches(ProposalStatusMatches),
 
-    // Query proposals and check if there're any passed proposals
-    #[returns(QueryResponse)]
+    // Query proposals and check if there are any passed proposals
+    #[returns(mod_sdk::types::QueryResponse)]
     HasPassedProposals { dao_address: String },
 
-    // Query proposals and check if there're any passed proposals with Wasm::Migration message
-    #[returns(QueryResponse)]
+    // Query proposals and check if there are any passed proposals with Wasm::Migration message
+    #[returns(mod_sdk::types::QueryResponse)]
     HasPassedProposalWithMigration { dao_address: String },
 
     // Check if the last proposal id is greater than specified value
-    #[returns(QueryResponse)]
+    #[returns(mod_sdk::types::QueryResponse)]
     HasProposalsGtId { dao_address: String, value: u64 },
 }

--- a/contracts/mod-generic/src/msg.rs
+++ b/contracts/mod-generic/src/msg.rs
@@ -1,7 +1,5 @@
 use crate::types::GenericQuery;
 use cosmwasm_schema::{cw_serde, QueryResponses};
-#[allow(unused_imports)]
-use mod_sdk::types::QueryResponse;
 
 #[cw_serde]
 pub struct InstantiateMsg {}
@@ -15,6 +13,6 @@ pub enum QueryMsg {
     // Create a generic query
     // Parse the json-like result to get the required value using `gets`
     // Compare it to `value` according to `ordering`
-    #[returns(QueryResponse)]
+    #[returns(mod_sdk::types::QueryResponse)]
     GenericQuery(GenericQuery),
 }

--- a/contracts/mod-generic/src/msg.rs
+++ b/contracts/mod-generic/src/msg.rs
@@ -1,5 +1,6 @@
 use crate::types::GenericQuery;
 use cosmwasm_schema::{cw_serde, QueryResponses};
+#[allow(unused_imports)]
 use mod_sdk::types::QueryResponse;
 
 #[cw_serde]

--- a/contracts/mod-nft/src/msg.rs
+++ b/contracts/mod-nft/src/msg.rs
@@ -1,6 +1,4 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
-#[allow(unused_imports)]
-use mod_sdk::types::QueryResponse;
 
 use crate::types::OwnerOfNft;
 
@@ -14,11 +12,11 @@ pub enum ExecuteMsg {}
 #[derive(QueryResponses)]
 pub enum QueryMsg {
     /// Check if `address` is the owner of the token
-    #[returns(QueryResponse)]
+    #[returns(mod_sdk::types::QueryResponse)]
     OwnerOfNft(OwnerOfNft),
 
     /// Check if `address` owns any tokens on `nft_address` contract
-    #[returns(QueryResponse)]
+    #[returns(mod_sdk::types::QueryResponse)]
     AddrHasNft {
         address: String,
         nft_address: String,

--- a/contracts/mod-nft/src/msg.rs
+++ b/contracts/mod-nft/src/msg.rs
@@ -1,4 +1,5 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
+#[allow(unused_imports)]
 use mod_sdk::types::QueryResponse;
 
 use crate::types::OwnerOfNft;

--- a/packages/croncat-sdk-agents/src/msg.rs
+++ b/packages/croncat-sdk-agents/src/msg.rs
@@ -1,6 +1,4 @@
 use crate::types::AgentStatus;
-#[allow(unused_imports)]
-use crate::types::Config;
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{Addr, Timestamp, Uint128, Uint64};
 use croncat_sdk_core::internal_messages::agents::AgentOnTaskCreated;
@@ -44,7 +42,7 @@ pub enum QueryMsg {
         block_slots: Option<u64>,
         cron_slots: Option<u64>,
     },
-    #[returns[Config]]
+    #[returns[crate::types::Config]]
     Config {},
 }
 

--- a/packages/croncat-sdk-agents/src/msg.rs
+++ b/packages/croncat-sdk-agents/src/msg.rs
@@ -1,4 +1,5 @@
 use crate::types::AgentStatus;
+#[allow(unused_imports)]
 use crate::types::Config;
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{Addr, Timestamp, Uint128, Uint64};

--- a/packages/croncat-sdk-manager/src/msg.rs
+++ b/packages/croncat-sdk-manager/src/msg.rs
@@ -1,12 +1,7 @@
 use crate::types::{GasPrice, UpdateConfig};
-#[allow(unused_imports)]
-use crate::types::Config;
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use croncat_sdk_core::internal_messages::manager::{ManagerCreateTaskBalance, ManagerRemoveTask};
 use cw20::Cw20Coin;
-#[allow(unused_imports)]
-use cw20::Cw20CoinVerified;
-
 
 #[cw_serde]
 pub struct ManagerInstantiateMsg {
@@ -68,13 +63,13 @@ pub enum ManagerExecuteMsg {
 #[derive(QueryResponses)]
 pub enum ManagerQueryMsg {
     /// Gets current croncat config
-    #[returns(Config)]
+    #[returns(crate::types::Config)]
     Config {},
     /// Gets manager available balances
     #[returns(cosmwasm_std::Uint128)]
     TreasuryBalance {},
     /// Gets Cw20 balances of the given wallet address
-    #[returns(Vec<Cw20CoinVerified>)]
+    #[returns(Vec<cw20::Cw20CoinVerified>)]
     UsersBalances {
         wallet: String,
         from_index: Option<u64>,

--- a/packages/croncat-sdk-manager/src/msg.rs
+++ b/packages/croncat-sdk-manager/src/msg.rs
@@ -1,7 +1,12 @@
-use crate::types::{Config, GasPrice, UpdateConfig};
+use crate::types::{GasPrice, UpdateConfig};
+#[allow(unused_imports)]
+use crate::types::Config;
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use croncat_sdk_core::internal_messages::manager::{ManagerCreateTaskBalance, ManagerRemoveTask};
-use cw20::{Cw20Coin, Cw20CoinVerified};
+use cw20::Cw20Coin;
+#[allow(unused_imports)]
+use cw20::Cw20CoinVerified;
+
 
 #[cw_serde]
 pub struct ManagerInstantiateMsg {


### PR DESCRIPTION
Cleaning up so we don't have this when running `just build`. Also making sure that `just test` works

<img width="583" alt="Screen Shot 2023-01-26 at 10 44 36 AM" src="https://user-images.githubusercontent.com/1042667/214922598-e2a56788-a62e-42ed-a0ea-fc7b87ee8124.png">
