### PR TITLE
Fix test dealing with doc-tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,6 +414,7 @@ dependencies = [
  "croncat-sdk-core",
  "cw20 0.16.0",
  "hex",
+ "mod-sdk",
  "sha2 0.10.6",
 ]
 

--- a/packages/croncat-sdk-tasks/Cargo.toml
+++ b/packages/croncat-sdk-tasks/Cargo.toml
@@ -13,6 +13,7 @@ cron_schedule = { workspace = true }
 
 croncat-mod-generic = { workspace = true, features = ["library"]}
 croncat-sdk-core = { workspace = true }
+mod-sdk = { workspace = true }
 
 sha2 = { workspace = true }
 hex = { workspace = true }

--- a/packages/croncat-sdk-tasks/src/types.rs
+++ b/packages/croncat-sdk-tasks/src/types.rs
@@ -294,7 +294,8 @@ pub struct CroncatQuery {
     ///
     /// One requirement for custom contracts: query return value should be formatted as:
     /// ```
-    /// {
+    /// use cosmwasm_std::Binary;
+    /// struct ReturnValue {
     ///     result: bool,
     ///     data: Binary,
     /// }

--- a/packages/croncat-sdk-tasks/src/types.rs
+++ b/packages/croncat-sdk-tasks/src/types.rs
@@ -292,14 +292,8 @@ pub struct CroncatQuery {
     /// This is address of the queried module contract.
     /// For the addr can use one of our croncat-mod-* contracts, or custom contracts
     ///
-    /// One requirement for custom contracts: query return value should be formatted as:
-    /// ```
-    /// use cosmwasm_std::Binary;
-    /// struct ReturnValue {
-    ///     result: bool,
-    ///     data: Binary,
-    /// }
-    /// ```
+    /// One requirement for custom contracts: query return value should be formatted as a:
+    /// [`QueryResponse`]: mod_sdk::types::QueryResponse
     pub contract_addr: String,
     pub msg: Binary,
     pub check_result: bool,


### PR DESCRIPTION
Teeny tiny thing that'll make `just test` pass. It was a comment with code that didn't follow:
https://doc.rust-lang.org/rust-by-example/meta/doc.html#doc-comments