### PR TITLE
fix QueryResponse doc comment to actually link there

### DIFF
--- a/packages/croncat-sdk-tasks/src/types.rs
+++ b/packages/croncat-sdk-tasks/src/types.rs
@@ -293,7 +293,7 @@ pub struct CroncatQuery {
     /// For the addr can use one of our croncat-mod-* contracts, or custom contracts
     ///
     /// One requirement for custom contracts: query return value should be formatted as a:
-    /// [`QueryResponse`]: mod_sdk::types::QueryResponse
+    /// [`QueryResponse`](mod_sdk::types::QueryResponse)
     pub contract_addr: String,
     pub msg: Binary,
     pub check_result: bool,


### PR DESCRIPTION
Per @Buckram123 noticing that it 

# DIDN'T ACTUALLY WORK, Mike!

I thought I might fix my work.