### PR TITLE
Disable the CI's gas-benchmarking as it's not a beta deliverable

### DIFF
--- a/.github/workflows/gas_benchmark.yml
+++ b/.github/workflows/gas_benchmark.yml
@@ -46,8 +46,8 @@ jobs:
       - name: Install just
         run: cargo install just || true
 
-      - name: Run Gas Benchmarks
-        run: just gas-benchmark
+#      - name: Run Gas Benchmarks
+#        run: just gas-benchmark
 
       - name: Raw Gas Report
         run: cat gas_reports/gas_report.json


### PR DESCRIPTION
Talked to Trevor about how this is not necessary at this point for our beta release.

Let's worry about this during the next phase of the roadmap.