### PR TITLE
CosmJS deploying manager: remove breaking params when isntantiating

### DIFF
--- a/scripts/deployment/src/manager.ts
+++ b/scripts/deployment/src/manager.ts
@@ -50,7 +50,7 @@ export class ManagerClient {
 			}
 		}
 
-		const instRes = await this.client.execute(sender, factoryAddress, deployMsg, executeGas, null, funds);
+		const instRes = await this.client.execute(sender, factoryAddress, deployMsg, executeGas);
 		const address: string = instRes.logs[0].events[1].attributes[0].value
 
 		return [codeId, address];


### PR DESCRIPTION
Removed some params that seemed to break how we derive the address.