### PR TITLE
For packages, add necessary manifest fields

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,9 @@ authors = [
   "deveusss",
 ]
 edition = "2021"
-description = "Croncat provides a general purpose, fully autonomous network that enables scheduled function calls for blockchain contract execution. It allows any application to schedule logic to get executed in the future, once or many times, triggered by an approved “agent,” in an economically stable format."
+description = "CronCat provides a general purpose, fully autonomous network that enables scheduled function calls for blockchain contract execution. It allows any application to schedule logic to get executed in the future, once or many times, triggered by an approved “agent,” in an economically stable format."
 documentation = "https://docs.cron.cat/"
+license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]
 serde = { version = "1.0" }
@@ -67,11 +68,11 @@ croncat-tasks = { path = "./contracts/croncat-tasks" }
 croncat-factory = { path = "./contracts/croncat-factory" }
 croncat-mod-balances = { path = "./contracts/mod-balances" }
 croncat-mod-dao = { path = "./contracts/mod-dao" }
-croncat-mod-generic = { path = "./contracts/mod-generic" }
+croncat-mod-generic = { path = "./contracts/mod-generic", version = "0.1.0" }
 croncat-mod-nft = { path = "./contracts/mod-nft" }
 croncat-sdk-agents = { path = "./packages/croncat-sdk-agents" }
-croncat-sdk-core = { path = "./packages/croncat-sdk-core" }
+croncat-sdk-core = { path = "./packages/croncat-sdk-core", version = "0.1.0" }
 croncat-sdk-tasks = { path = "./packages/croncat-sdk-tasks" }
-mod-sdk = { path = "./packages/mod-sdk" }
+mod-sdk = { path = "./packages/mod-sdk", version = "0.1.0" }
 croncat-sdk-factory = { path = "./packages/croncat-sdk-factory" }
 croncat-sdk-manager = { path = "./packages/croncat-sdk-manager" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,11 +68,11 @@ croncat-tasks = { path = "./contracts/croncat-tasks" }
 croncat-factory = { path = "./contracts/croncat-factory" }
 croncat-mod-balances = { path = "./contracts/mod-balances" }
 croncat-mod-dao = { path = "./contracts/mod-dao" }
-croncat-mod-generic = { path = "./contracts/mod-generic", version = "0.1.0" }
+croncat-mod-generic = { path = "./contracts/mod-generic" }
 croncat-mod-nft = { path = "./contracts/mod-nft" }
 croncat-sdk-agents = { path = "./packages/croncat-sdk-agents" }
-croncat-sdk-core = { path = "./packages/croncat-sdk-core", version = "0.1.0" }
+croncat-sdk-core = { path = "./packages/croncat-sdk-core" }
 croncat-sdk-tasks = { path = "./packages/croncat-sdk-tasks" }
-mod-sdk = { path = "./packages/mod-sdk", version = "0.1.0" }
+mod-sdk = { path = "./packages/mod-sdk" }
 croncat-sdk-factory = { path = "./packages/croncat-sdk-factory" }
 croncat-sdk-manager = { path = "./packages/croncat-sdk-manager" }

--- a/contracts/mod-generic/Cargo.toml
+++ b/contracts/mod-generic/Cargo.toml
@@ -5,7 +5,7 @@ authors = []
 edition = "2021"
 repository = "https://github.com/CronCats/cw-croncat"
 license = { workspace = true }
-description = "Allows for CosmWasm raw queries through this module, helpful when making CronCat tasks with queries"
+description = "Allows to deserialize any CosmWasm smart contract's queue response and check the results of any fields."
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/contracts/mod-generic/Cargo.toml
+++ b/contracts/mod-generic/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.1.0"
 authors = []
 edition = "2021"
 repository = "https://github.com/CronCats/cw-croncat"
+license = { workspace = true }
+description = "Allows for CosmWasm raw queries through this module, helpful when making CronCat tasks with queries"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/contracts/mod-generic/src/contract.rs
+++ b/contracts/mod-generic/src/contract.rs
@@ -46,7 +46,7 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
 }
 
 /// Query: GenericQuery
-/// Used for creating generic quieries
+/// Used for creating generic queries
 /// Parses the query result to receive the value according to the path, defined by `gets`
 /// Compares this result with a pre-defined value
 /// ValueOrdering allows several options for comparison:

--- a/packages/croncat-sdk-agents/Cargo.toml
+++ b/packages/croncat-sdk-agents/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.1.0"
 authors = []
 edition = "2021"
 repository = "https://github.com/CronCats/cw-croncat"
+license = { workspace = true }
+description = "CronCat agents package containing CosmWasm types, messages, and errors."
 
 [dependencies]
 cosmwasm-std = { workspace = true }

--- a/packages/croncat-sdk-core/Cargo.toml
+++ b/packages/croncat-sdk-core/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.1.0"
 authors = { workspace = true }
 edition = "2021"
 repository = "https://github.com/CronCats/cw-croncat"
+license = { workspace = true }
+description = "Contains structs and impls useful in the operation of CronCat automation"
 
 [dependencies]
 cosmwasm-schema = { workspace = true }

--- a/packages/croncat-sdk-core/Cargo.toml
+++ b/packages/croncat-sdk-core/Cargo.toml
@@ -9,5 +9,5 @@ description = "Contains structs and impls useful in the operation of CronCat aut
 
 [dependencies]
 cosmwasm-schema = { workspace = true }
-cosmwasm-std = { worskpace = true }
+cosmwasm-std = { workspace = true }
 cw20 = { workspace = true }

--- a/packages/croncat-sdk-factory/Cargo.toml
+++ b/packages/croncat-sdk-factory/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.1.0"
 authors = { workspace = true }
 edition = "2021"
 repository = "https://github.com/CronCats/cw-croncat"
+license = { workspace = true }
+description = "CronCat factory package containing types and messages."
 
 [dependencies]
 cosmwasm-schema = { workspace = true }

--- a/packages/croncat-sdk-manager/Cargo.toml
+++ b/packages/croncat-sdk-manager/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.1.0"
 authors = { workspace = true }
 edition = "2021"
 repository = "https://github.com/CronCats/cw-croncat"
+license = { workspace = true }
+description = "CronCat Manager types, messages, and errors."
 
 [dependencies]
 cosmwasm-std = { workspace = true }

--- a/packages/croncat-sdk-tasks/Cargo.toml
+++ b/packages/croncat-sdk-tasks/Cargo.toml
@@ -14,7 +14,7 @@ cw20 = { workspace = true }
 cron_schedule = { workspace = true }
 
 croncat-mod-generic = { workspace = true, features = ["library"]}
-croncat-sdk-core = { workspace = true, path = "../croncat-sdk-core" }
+croncat-sdk-core = { workspace = true }
 mod-sdk = { workspace = true }
 
 sha2 = { workspace = true }

--- a/packages/croncat-sdk-tasks/Cargo.toml
+++ b/packages/croncat-sdk-tasks/Cargo.toml
@@ -12,7 +12,7 @@ cw20 = { workspace = true }
 cron_schedule = { workspace = true }
 
 croncat-mod-generic = { workspace = true, features = ["library"]}
-croncat-sdk-core = { workspace = true }
+croncat-sdk-core = { workspace = true, path = "../croncat-sdk-core" }
 mod-sdk = { workspace = true }
 
 sha2 = { workspace = true }

--- a/packages/croncat-sdk-tasks/Cargo.toml
+++ b/packages/croncat-sdk-tasks/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.1.0"
 authors = { workspace = true }
 edition = "2021"
 repository = "https://github.com/CronCats/cw-croncat"
+license = { workspace = true }
+description = "CronCat tasks package containing CosmWasm types and messages"
 
 [dependencies]
 cosmwasm-std = { workspace = true }

--- a/packages/mod-sdk/Cargo.toml
+++ b/packages/mod-sdk/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.1.0"
 authors = []
 edition = "2021"
 repository = "https://github.com/CronCats/cw-croncat"
+license = { workspace = true }
+description = "Contains basic types and errors useful for CronCat modules"
 
 [dependencies]
 cosmwasm-schema = { workspace = true }


### PR DESCRIPTION
All the packages are on crates.io now, and in that process it makes us add useful things like a description.

Did the thing