### PR TITLE
README in query contracts and packages

### DIFF
--- a/contracts/mod-balances/Cargo.toml
+++ b/contracts/mod-balances/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.1.0"
 authors = []
 edition = "2021"
 repository = "https://github.com/CronCats/cw-croncat"
+license = { workspace = true }
+description = "Allows querying CosmWasm balances, helpful when making CronCat tasks with queries."
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/contracts/mod-balances/README.md
+++ b/contracts/mod-balances/README.md
@@ -1,0 +1,13 @@
+# CronCats contract for balances queries
+
+The contract can perform these queries:
+
+| Query                  | Description                                                             |
+| ---------------------- | ----------------------------------------------------------------------- |
+| GetBalance             | Get native balance of the address                                       |
+| GetCw20Balance         | Get cw20 balance of the address                                         |
+| HasBalanceComparator   | Compare balance of the address to the given coin (either native or cw20)|
+
+*** 
+
+This contract doesn't support `Execute` actions and it doesn't have any state.

--- a/contracts/mod-dao/Cargo.toml
+++ b/contracts/mod-dao/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.1.0"
 authors = []
 edition = "2021"
 repository = "https://github.com/CronCats/cw-croncat"
+license = { workspace = true }
+description = "Provides CosmWasm queries of DAO contracts, helpful when making CronCat tasks with queries."
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/contracts/mod-dao/README.md
+++ b/contracts/mod-dao/README.md
@@ -1,0 +1,14 @@
+# CronCats contract for DAO queries
+
+The contract performs these queries:
+
+| Query                          | Description                                                                    |
+| ------------------------------ | ------------------------------------------------------------------------------ |
+| ProposalStatusMatches          | Get proposal status and compare it to the given status                         |
+| HasPassedProposals             | Check if DAO has passed proposals, get the list of them                        |
+| HasPassedProposalWithMigration | Check if DAO has passed proposals with migration message, get the list of them |
+| HasProposalsGtId               | Check if the last proposal id is greater than the given value                  |
+
+*** 
+
+This contract doesn't support `Execute` actions and it doesn't have any state.

--- a/contracts/mod-generic/Cargo.toml
+++ b/contracts/mod-generic/Cargo.toml
@@ -5,7 +5,7 @@ authors = []
 edition = "2021"
 repository = "https://github.com/CronCats/cw-croncat"
 license = { workspace = true }
-description = "Allows to deserialize any CosmWasm smart contract's queue response and check the results of any fields."
+description = "Allows for CosmWasm raw queries through this module, helpful when making CronCat tasks with queries."
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/contracts/mod-generic/README.md
+++ b/contracts/mod-generic/README.md
@@ -1,0 +1,11 @@
+# CronCats contract for generic query
+
+The contract has one query:
+
+| Query                 | Description                                                         |
+| --------------------- | ------------------------------------------------------------------- |
+| GenericQuery          | Сreates a generic query, compares the result to a pre-defined value |
+
+*** 
+
+This contract doesn't support `Execute` actions and it doesn't have any state.

--- a/contracts/mod-nft/Cargo.toml
+++ b/contracts/mod-nft/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.1.0"
 authors = []
 edition = "2021"
 repository = "https://github.com/CronCats/cw-croncat"
+license = { workspace = true }
+description = "Provides CosmWasm queries of NFT contracts, helpful when making CronCat tasks with queries."
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/contracts/mod-nft/README.md
+++ b/contracts/mod-nft/README.md
@@ -1,0 +1,12 @@
+# CronCats contract for NFT queries
+
+The contract has two queries:
+
+| Query                  | Description                                                   |
+| ---------------------- | ------------------------------------------------------------- |
+| OwnerOfNft             | Get the owner of the NFT, check if it's the specified address |
+| AddrHasNft             | Check if the address has any NFTs, get a list of them         |
+
+*** 
+
+This contract doesn't support `Execute` actions and it doesn't have any state.

--- a/packages/croncat-sdk-agents/README.md
+++ b/packages/croncat-sdk-agents/README.md
@@ -1,0 +1,5 @@
+# CronCat SDK Agents
+
+This package contains messages, types and errors for CronCat Agents contract.
+
+To see the full list of actions see Agents contract [docs](https://github.com/CronCats/cw-croncat/blob/beta/split-0.0.0/contracts/croncat-agents/README.md).

--- a/packages/croncat-sdk-factory/README.md
+++ b/packages/croncat-sdk-factory/README.md
@@ -1,0 +1,5 @@
+# CronCat SDK Factory
+
+This package contains messages, types and errors for CronCat Factory contract.
+
+To see the full list of actions see Factory contract [docs](https://github.com/CronCats/cw-croncat/blob/beta/split-0.0.0/contracts/croncat-factory/README.md).

--- a/packages/croncat-sdk-manager/README.md
+++ b/packages/croncat-sdk-manager/README.md
@@ -1,0 +1,5 @@
+# CronCat SDK Manager
+
+This package contains messages, types and errors for CronCat Manager contract.
+
+To see the full list of actions see Manager contract [docs](https://github.com/CronCats/cw-croncat/blob/beta/split-0.0.0/contracts/croncat-manager/README.md).

--- a/packages/croncat-sdk-tasks/README.md
+++ b/packages/croncat-sdk-tasks/README.md
@@ -1,0 +1,5 @@
+# CronCat SDK Tasks
+
+This package contains messages, types and errors for CronCat Tasks contract.
+
+To see the full list of actions see Tasks contract [docs](https://github.com/CronCats/cw-croncat/blob/beta/split-0.0.0/contracts/croncat-tasks/README.md).

--- a/packages/mod-sdk/README.md
+++ b/packages/mod-sdk/README.md
@@ -1,0 +1,5 @@
+# CronCat SDK Mod
+
+This package contains some helpful errors and response type for query contracts, which are used for making CronCat tasks with queries.
+
+The SDK Mod package is used in [Balances](https://github.com/CronCats/cw-croncat/tree/beta/split-0.0.0/contracts/mod-balances), [NFT](https://github.com/CronCats/cw-croncat/tree/beta/split-0.0.0/contracts/mod-nft), [DAO](https://github.com/CronCats/cw-croncat/tree/beta/split-0.0.0/contracts/mod-dao) and [Generic](https://github.com/CronCats/cw-croncat/tree/beta/split-0.0.0/contracts/mod-generic) query contracts.


### PR DESCRIPTION
There are new READMEs for query contracts, similar to docs we have for agent, manager and tasks contracts.

Also added small READMEs for packages, let me know if these should be more detailed or include the same tables as in the docs for corresponding contracts.