### PR TITLE
added the overflow checks

### DIFF
--- a/contracts/croncat-agents/Cargo.toml
+++ b/contracts/croncat-agents/Cargo.toml
@@ -8,6 +8,17 @@ repository = "https://github.com/CronCats/cw-croncat"
 [lib]
 crate-type = ["cdylib", "rlib"]
 
+[profile.release]
+codegen-units = 1
+opt-level = 3
+debug = false
+rpath = false
+lto = true
+debug-assertions = false
+panic = 'abort'
+incremental = false
+overflow-checks = true
+
 [features]
 # for more explicit tests, cargo test --features=backtraces
 backtraces = ["cosmwasm-std/backtraces"]

--- a/contracts/croncat-factory/Cargo.toml
+++ b/contracts/croncat-factory/Cargo.toml
@@ -8,6 +8,17 @@ repository = "https://github.com/CronCats/cw-croncat"
 [lib]
 crate-type = ["cdylib", "rlib"]
 
+[profile.release]
+codegen-units = 1
+opt-level = 3
+debug = false
+rpath = false
+lto = true
+debug-assertions = false
+panic = 'abort'
+incremental = false
+overflow-checks = true
+
 [features]
 # for more explicit tests, cargo test --features=backtraces
 backtraces = ["cosmwasm-std/backtraces"]

--- a/contracts/croncat-manager/Cargo.toml
+++ b/contracts/croncat-manager/Cargo.toml
@@ -8,6 +8,17 @@ repository = "https://github.com/CronCats/cw-croncat"
 [lib]
 crate-type = ["cdylib", "rlib"]
 
+[profile.release]
+codegen-units = 1
+opt-level = 3
+debug = false
+rpath = false
+lto = true
+debug-assertions = false
+panic = 'abort'
+incremental = false
+overflow-checks = true
+
 [features]
 # for more explicit tests, cargo test --features=backtraces
 backtraces = ["cosmwasm-std/backtraces"]

--- a/contracts/croncat-tasks/Cargo.toml
+++ b/contracts/croncat-tasks/Cargo.toml
@@ -8,6 +8,17 @@ repository = "https://github.com/CronCats/cw-croncat"
 [lib]
 crate-type = ["cdylib", "rlib"]
 
+[profile.release]
+codegen-units = 1
+opt-level = 3
+debug = false
+rpath = false
+lto = true
+debug-assertions = false
+panic = 'abort'
+incremental = false
+overflow-checks = true
+
 [features]
 # for more explicit tests, cargo test --features=backtraces
 backtraces = ["cosmwasm-std/backtraces"]

--- a/contracts/mod-balances/Cargo.toml
+++ b/contracts/mod-balances/Cargo.toml
@@ -10,6 +10,17 @@ description = "Allows querying CosmWasm balances, helpful when making CronCat ta
 [lib]
 crate-type = ["cdylib", "rlib"]
 
+[profile.release]
+codegen-units = 1
+opt-level = 3
+debug = false
+rpath = false
+lto = true
+debug-assertions = false
+panic = 'abort'
+incremental = false
+overflow-checks = true
+
 [features]
 # for more explicit tests, cargo test --features=backtraces
 backtraces = ["cosmwasm-std/backtraces"]

--- a/contracts/mod-dao/Cargo.toml
+++ b/contracts/mod-dao/Cargo.toml
@@ -10,6 +10,17 @@ description = "Provides CosmWasm queries of DAO contracts, helpful when making C
 [lib]
 crate-type = ["cdylib", "rlib"]
 
+[profile.release]
+codegen-units = 1
+opt-level = 3
+debug = false
+rpath = false
+lto = true
+debug-assertions = false
+panic = 'abort'
+incremental = false
+overflow-checks = true
+
 [features]
 # for more explicit tests, cargo test --features=backtraces
 backtraces = ["cosmwasm-std/backtraces"]

--- a/contracts/mod-generic/Cargo.toml
+++ b/contracts/mod-generic/Cargo.toml
@@ -10,6 +10,17 @@ description = "Allows for CosmWasm raw queries through this module, helpful when
 [lib]
 crate-type = ["cdylib", "rlib"]
 
+[profile.release]
+codegen-units = 1
+opt-level = 3
+debug = false
+rpath = false
+lto = true
+debug-assertions = false
+panic = 'abort'
+incremental = false
+overflow-checks = true
+
 [features]
 # for more explicit tests, cargo test --features=backtraces
 backtraces = ["cosmwasm-std/backtraces"]

--- a/contracts/mod-nft/Cargo.toml
+++ b/contracts/mod-nft/Cargo.toml
@@ -10,6 +10,17 @@ description = "Provides CosmWasm queries of NFT contracts, helpful when making C
 [lib]
 crate-type = ["cdylib", "rlib"]
 
+[profile.release]
+codegen-units = 1
+opt-level = 3
+debug = false
+rpath = false
+lto = true
+debug-assertions = false
+panic = 'abort'
+incremental = false
+overflow-checks = true
+
 [features]
 # for more explicit tests, cargo test --features=backtraces
 backtraces = ["cosmwasm-std/backtraces"]


### PR DESCRIPTION
based on the recommendation for overflow checks on each contract.

`recommend enabling overflow checks in all packages, including those that do not currently perform calculations, to prevent unintended consequences if changes are added in future releases or during refactoring. Note that enabling overflow checks in packages other than the workspace manifest will lead to compiler warnings.`

However, now adds warnings:
```
warning: profiles for the non root package will be ignored, specify profiles at the workspace root:
package:   /cw-croncat/contracts/croncat-agents/Cargo.toml
workspace: /cw-croncat/Cargo.toml
warning: profiles for the non root package will be ignored, specify profiles at the workspace root:
package:   /cw-croncat/contracts/mod-generic/Cargo.toml
workspace: /cw-croncat/Cargo.toml
warning: profiles for the non root package will be ignored, specify profiles at the workspace root:
package:   /cw-croncat/contracts/croncat-factory/Cargo.toml
workspace: /cw-croncat/Cargo.toml
warning: profiles for the non root package will be ignored, specify profiles at the workspace root:
package:   /cw-croncat/contracts/croncat-manager/Cargo.toml
workspace: /cw-croncat/Cargo.toml
warning: profiles for the non root package will be ignored, specify profiles at the workspace root:
package:   /cw-croncat/contracts/mod-balances/Cargo.toml
workspace: /cw-croncat/Cargo.toml
warning: profiles for the non root package will be ignored, specify profiles at the workspace root:
package:   /cw-croncat/contracts/croncat-tasks/Cargo.toml
workspace: /cw-croncat/Cargo.toml
warning: profiles for the non root package will be ignored, specify profiles at the workspace root:
package:   /cw-croncat/contracts/mod-dao/Cargo.toml
workspace: /cw-croncat/Cargo.toml
warning: profiles for the non root package will be ignored, specify profiles at the workspace root:
package:   /cw-croncat/contracts/mod-nft/Cargo.toml
workspace: /cw-croncat/Cargo.toml
```