### PR TITLE
Add 2 references back, a breaking clippy suggestion

### DIFF
--- a/contracts/croncat-agents/src/contract.rs
+++ b/contracts/croncat-agents/src/contract.rs
@@ -637,7 +637,7 @@ fn get_agent_status(
     // If agent is pending, Check if they should get nominated to checkin to become active
     let agent_position = if let Some(pos) = pending_iter.position(|address| {
         if let Ok(addr) = address {
-            addr == account_id
+            &addr == account_id
         } else {
             false
         }

--- a/contracts/croncat-agents/src/contract.rs
+++ b/contracts/croncat-agents/src/contract.rs
@@ -625,6 +625,7 @@ pub fn execute_update_config(
 }
 
 /// Note that we ran into problems with clippy here
+/// See https://github.com/CronCats/cw-croncat/pull/415
 #[allow(clippy::op_ref)]
 fn get_agent_status(
     storage: &dyn Storage,

--- a/contracts/croncat-agents/src/contract.rs
+++ b/contracts/croncat-agents/src/contract.rs
@@ -624,6 +624,8 @@ pub fn execute_update_config(
     Ok(Response::new().add_attribute("action", "update_config"))
 }
 
+/// Note that we ran into problems with clippy here
+#[allow(clippy::op_ref)]
 fn get_agent_status(
     storage: &dyn Storage,
     env: Env,

--- a/contracts/croncat-agents/src/distributor.rs
+++ b/contracts/croncat-agents/src/distributor.rs
@@ -36,6 +36,9 @@ impl AgentTaskDistributor {
         AgentTaskDistributor {}
     }
 }
+
+/// Note that we ran into problems with clippy here
+#[allow(clippy::op_ref)]
 impl<'a> RoundRobinAgentTaskDistributor<'a> for AgentTaskDistributor {
     fn get_agent_tasks(
         &self,

--- a/contracts/croncat-agents/src/distributor.rs
+++ b/contracts/croncat-agents/src/distributor.rs
@@ -38,6 +38,7 @@ impl AgentTaskDistributor {
 }
 
 /// Note that we ran into problems with clippy here
+/// See <https://github.com/CronCats/cw-croncat/pull/415>
 #[allow(clippy::op_ref)]
 impl<'a> RoundRobinAgentTaskDistributor<'a> for AgentTaskDistributor {
     fn get_agent_tasks(

--- a/contracts/croncat-agents/src/distributor.rs
+++ b/contracts/croncat-agents/src/distributor.rs
@@ -85,7 +85,7 @@ impl<'a> RoundRobinAgentTaskDistributor<'a> for AgentTaskDistributor {
             });
             let agent_diff_index = active
                 .iter()
-                .position(|x| x == agent_id)
+                .position(|x| x == &agent_id)
                 .ok_or(ContractError::AgentNotRegistered {})?
                 as u64;
 


### PR DESCRIPTION
In commit [0a54e4854cf9efb9d220c10318e26f27aa59191c](https://github.com/CronCats/cw-croncat/commit/0a54e4854cf9efb9d220c10318e26f27aa59191c) I followed directions from two clippy warnings to remove references.

```
warning: needlessly taken reference of left operand
   --> contracts/croncat-agents/src/contract.rs:640:13
    |
640 |             &addr == account_id
    |             -----^^^^^^^^^^^^^^
    |             |
    |             help: use the left value directly: `addr`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#op_ref
    = note: `#[warn(clippy::op_ref)]` on by default

warning: taken reference of right operand
  --> contracts/croncat-agents/src/distributor.rs:88:31
   |
88 |                 .position(|x| x == &agent_id)
   |                               ^^^^^---------
   |                                    |
   |                                    help: use the right value directly: `agent_id`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#op_ref
```

<img width="1347" alt="Screen Shot 2023-05-16 at 12 11 12 PM" src="https://github.com/CronCats/cw-croncat/assets/1042667/72030581-5ba4-47a8-9765-b115e34d9049">

The good folks from VectisDAO pointed out that this was problematic when using the `croncat-integration-testing` crate.

Oddly enough, I believe this warning from clippy should not be followed or it'll break things.

Added `#[allow(clippy::op_ref)]` to both methods where clippy gets confused and throws a warning. I prefer this approach to changing CI to consider warnings as errors like we have here:

https://github.com/CronCats/cw-croncat/blob/62acb73074f60096ebae28e04f7f2478cd11650f/.github/workflows/Basic.yml#L72