### PR TITLE
Loosen version restriction on `cosmwasm-schema` and bump `cosmwasm` crates.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,9 +158,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema"
-version = "1.1.9"
+version = "1.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04135971e2c3b867eb793ca4e832543c077dbf72edaef7672699190f8fcdb619"
+checksum = "0f00b363610218eea83f24bbab09e1a7c3920b79f068334fdfcc62f6129ef9fc"
 dependencies = [
  "cosmwasm-schema-derive",
  "schemars",
@@ -171,9 +171,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-schema-derive"
-version = "1.1.9"
+version = "1.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06c8f516a13ae481016aa35f0b5c4652459e8aee65b15b6fb51547a07cea5a0"
+checksum = "ae38f909b2822d32b275c9e2db9728497aa33ffe67dd463bc67c6a3b7092785c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -237,38 +237,18 @@ dependencies = [
  "anyhow",
  "cosmwasm-schema",
  "cosmwasm-std",
- "croncat-agents 1.0.0",
- "croncat-factory 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "croncat-manager 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "croncat-sdk-agents 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "croncat-sdk-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "croncat-sdk-factory 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "croncat-sdk-manager 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "croncat-sdk-tasks 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "croncat-tasks 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "croncat-agents",
+ "croncat-factory",
+ "croncat-manager",
+ "croncat-sdk-agents",
+ "croncat-sdk-core",
+ "croncat-sdk-factory",
+ "croncat-sdk-manager",
+ "croncat-sdk-tasks",
+ "croncat-tasks",
  "cw-multi-test",
  "cw-storage-plus 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw-utils 0.16.0",
- "cw2 1.0.1",
- "serde",
- "thiserror",
-]
-
-[[package]]
-name = "croncat-agents"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6fe45bb71662e0a1cba7a00bb9df1d2e5ffa67ab48499164208874d07932df4"
-dependencies = [
- "cosmwasm-schema",
- "cosmwasm-std",
- "croncat-sdk-agents 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "croncat-sdk-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "croncat-sdk-factory 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "croncat-sdk-manager 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "croncat-sdk-tasks 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw-storage-plus 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw-utils 0.16.0",
+ "cw-utils 1.0.1",
  "cw2 1.0.1",
  "serde",
  "thiserror",
@@ -291,35 +271,19 @@ dependencies = [
  "anyhow",
  "cosmwasm-schema",
  "cosmwasm-std",
- "croncat-agents 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "croncat-manager 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "croncat-mod-balances 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "croncat-sdk-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "croncat-sdk-factory 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "croncat-sdk-manager 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "croncat-tasks 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "croncat-agents",
+ "croncat-manager",
+ "croncat-mod-balances",
+ "croncat-sdk-core",
+ "croncat-sdk-factory",
+ "croncat-sdk-manager",
+ "croncat-tasks",
  "cw-multi-test",
  "cw-storage-plus 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw-utils 0.16.0",
+ "cw-utils 1.0.1",
  "cw2 1.0.1",
- "cw20 0.16.0",
- "cw20-base 0.16.0",
- "thiserror",
-]
-
-[[package]]
-name = "croncat-factory"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53ccce2e8439b69b1208f6435803010ee5ca724be3973fe37a91bc143f30f05"
-dependencies = [
- "cosmwasm-schema",
- "cosmwasm-std",
- "croncat-sdk-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "croncat-sdk-factory 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw-storage-plus 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw-utils 0.16.0",
- "cw2 1.0.1",
+ "cw20 1.0.1",
+ "cw20-base 1.0.1",
  "thiserror",
 ]
 
@@ -329,17 +293,17 @@ version = "1.0.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "croncat-agents 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "croncat-factory 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "croncat-manager 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "croncat-sdk-agents 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "croncat-sdk-factory 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "croncat-sdk-manager 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "croncat-sdk-tasks 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "croncat-tasks 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "croncat-agents",
+ "croncat-factory",
+ "croncat-manager",
+ "croncat-sdk-agents",
+ "croncat-sdk-factory",
+ "croncat-sdk-manager",
+ "croncat-sdk-tasks",
+ "croncat-tasks",
  "cw-multi-test",
- "cw-utils 0.16.0",
- "cw20 0.16.0",
+ "cw-utils 1.0.1",
+ "cw20 1.0.1",
  "serde-json-wasm",
  "serde_json",
  "thiserror",
@@ -351,14 +315,14 @@ version = "1.0.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "croncat-mod-generic 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "croncat-sdk-agents 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "croncat-sdk-factory 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "croncat-sdk-manager 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "croncat-sdk-tasks 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "croncat-mod-generic",
+ "croncat-sdk-agents",
+ "croncat-sdk-factory",
+ "croncat-sdk-manager",
+ "croncat-sdk-tasks",
  "cw-multi-test",
- "cw-utils 0.16.0",
- "cw20 0.16.0",
+ "cw-utils 1.0.1",
+ "cw20 1.0.1",
  "serde-json-wasm",
  "serde_json",
  "thiserror",
@@ -370,24 +334,23 @@ version = "1.0.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "croncat-agents 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "croncat-factory 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "croncat-mod-balances 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "croncat-mod-generic 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "croncat-sdk-agents 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "croncat-sdk-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "croncat-sdk-factory 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "croncat-sdk-manager 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "croncat-sdk-tasks 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "croncat-tasks 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw-boolean-contract",
+ "croncat-agents",
+ "croncat-factory",
+ "croncat-mod-balances",
+ "croncat-mod-generic",
+ "croncat-sdk-agents",
+ "croncat-sdk-core",
+ "croncat-sdk-factory",
+ "croncat-sdk-manager",
+ "croncat-sdk-tasks",
+ "croncat-tasks",
  "cw-multi-test",
  "cw-storage-plus 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw-utils 0.16.0",
+ "cw-utils 1.0.1",
  "cw2 1.0.1",
- "cw20 0.16.0",
- "cw20-base 0.16.0",
- "mod-sdk 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw20 1.0.1",
+ "cw20-base 1.0.1",
+ "mod-sdk",
  "serde-cw-value",
  "serde-json-wasm",
  "serde_json",
@@ -395,53 +358,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "croncat-manager"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c8e633987259b1a4e33b52eed9c1e47afc14fe30d52d41f75395859d17ce350"
-dependencies = [
- "cosmwasm-schema",
- "cosmwasm-std",
- "croncat-sdk-agents 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "croncat-sdk-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "croncat-sdk-factory 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "croncat-sdk-manager 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "croncat-sdk-tasks 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw-storage-plus 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw-utils 0.16.0",
- "cw2 1.0.1",
- "cw20 0.16.0",
- "mod-sdk 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde-cw-value",
- "serde-json-wasm",
- "thiserror",
-]
-
-[[package]]
 name = "croncat-mod-balances"
 version = "1.0.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-multi-test",
- "cw-utils 0.16.0",
+ "cw-utils 1.0.1",
  "cw2 1.0.1",
- "cw20 0.16.0",
- "cw20-base 0.16.0",
- "mod-sdk 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "croncat-mod-balances"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff5a60d1b68c70c1899903895f787adfba9fa270845456f14dbc8054361b8665"
-dependencies = [
- "cosmwasm-schema",
- "cosmwasm-std",
- "cw2 1.0.1",
- "cw20 0.16.0",
- "mod-sdk 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw20 1.0.1",
+ "cw20-base 1.0.1",
+ "mod-sdk",
 ]
 
 [[package]]
@@ -451,10 +378,10 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-multi-test",
- "cw-utils 0.16.0",
+ "cw-utils 1.0.1",
  "cw2 1.0.1",
- "cw20 0.16.0",
- "cw20-base 0.16.0",
+ "cw20 1.0.1",
+ "cw20-base 1.0.1",
  "cw20-stake 2.1.0",
  "dao-core",
  "dao-interface",
@@ -462,7 +389,7 @@ dependencies = [
  "dao-proposal-single",
  "dao-voting",
  "dao-voting-cw20-staked",
- "mod-sdk 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mod-sdk",
  "schemars",
  "serde",
 ]
@@ -473,32 +400,18 @@ version = "1.0.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "croncat-mod-balances 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "croncat-mod-balances",
  "cw-multi-test",
- "cw-utils 0.16.0",
+ "cw-utils 1.0.1",
  "cw2 1.0.1",
- "cw20 0.16.0",
- "cw20-base 0.16.0",
+ "cw20 1.0.1",
+ "cw20-base 1.0.1",
  "cw4",
  "cw4-group",
- "mod-sdk 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mod-sdk",
  "serde-cw-value",
  "serde-json-wasm",
  "serde_json",
-]
-
-[[package]]
-name = "croncat-mod-generic"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "382e6be5c60aae529dfcbac85a351832a7b6086db099b7ce41371e57e11fb14f"
-dependencies = [
- "cosmwasm-schema",
- "cosmwasm-std",
- "cw2 1.0.1",
- "mod-sdk 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde-cw-value",
- "serde-json-wasm",
 ]
 
 [[package]]
@@ -509,9 +422,9 @@ dependencies = [
  "cosmwasm-std",
  "cw-multi-test",
  "cw2 1.0.1",
- "cw721 0.16.0",
- "cw721-base",
- "mod-sdk 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw721 0.17.0",
+ "cw721-base 0.17.0",
+ "mod-sdk",
 ]
 
 [[package]]
@@ -520,20 +433,7 @@ version = "1.0.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "croncat-sdk-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde",
- "thiserror",
-]
-
-[[package]]
-name = "croncat-sdk-agents"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d80604d4fd1a2594b589258357ca25bb8c922c258d91267c0209b4d204944584"
-dependencies = [
- "cosmwasm-schema",
- "cosmwasm-std",
- "croncat-sdk-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "croncat-sdk-core",
  "serde",
  "thiserror",
 ]
@@ -544,19 +444,7 @@ version = "1.0.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw20 0.16.0",
- "thiserror",
-]
-
-[[package]]
-name = "croncat-sdk-core"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e486cf063b6cbb01195b7311ee5dad3afd6af2225872a961f9097f3a5709b2fb"
-dependencies = [
- "cosmwasm-schema",
- "cosmwasm-std",
- "cw20 0.16.0",
+ "cw20 1.0.1",
  "thiserror",
 ]
 
@@ -570,41 +458,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "croncat-sdk-factory"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49598925e610e846d26a45a606fa4fbe9bfa2245f567da506f1e4816b9339e39"
-dependencies = [
- "cosmwasm-schema",
- "cosmwasm-std",
- "cw-storage-plus 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "croncat-sdk-manager"
 version = "1.0.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "croncat-sdk-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "croncat-sdk-tasks 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "croncat-sdk-core",
+ "croncat-sdk-tasks",
  "cw-storage-plus 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw20 0.16.0",
- "thiserror",
-]
-
-[[package]]
-name = "croncat-sdk-manager"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e0096bbb64df2c73f8fb34cb486d51fdfce96493841131cffd7dbbe219f62e"
-dependencies = [
- "cosmwasm-schema",
- "cosmwasm-std",
- "croncat-sdk-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "croncat-sdk-tasks 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw-storage-plus 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw20 0.16.0",
+ "cw20 1.0.1",
  "thiserror",
 ]
 
@@ -615,28 +477,11 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cron_schedule",
- "croncat-mod-generic 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "croncat-sdk-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw20 0.16.0",
+ "croncat-mod-generic",
+ "croncat-sdk-core",
+ "cw20 1.0.1",
  "hex",
- "mod-sdk 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha2 0.10.6",
-]
-
-[[package]]
-name = "croncat-sdk-tasks"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0afbf4dc9af7623f08232245f9f02b0dff2da72a8195554c05e02289ccbac616"
-dependencies = [
- "cosmwasm-schema",
- "cosmwasm-std",
- "cron_schedule",
- "croncat-mod-generic 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "croncat-sdk-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw20 0.16.0",
- "hex",
- "mod-sdk 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mod-sdk",
  "sha2 0.10.6",
 ]
 
@@ -647,45 +492,23 @@ dependencies = [
  "anyhow",
  "cosmwasm-schema",
  "cosmwasm-std",
- "croncat-agents 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "croncat-factory 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "croncat-manager 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "croncat-mod-balances 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "croncat-mod-generic 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "croncat-sdk-agents 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "croncat-sdk-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "croncat-sdk-factory 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "croncat-sdk-manager 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "croncat-sdk-tasks 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "croncat-agents",
+ "croncat-factory",
+ "croncat-manager",
+ "croncat-mod-balances",
+ "croncat-mod-generic",
+ "croncat-sdk-agents",
+ "croncat-sdk-core",
+ "croncat-sdk-factory",
+ "croncat-sdk-manager",
+ "croncat-sdk-tasks",
  "cw-multi-test",
  "cw-storage-plus 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw-utils 0.16.0",
+ "cw-utils 1.0.1",
  "cw2 1.0.1",
- "cw20 0.16.0",
- "cw20-base 0.16.0",
- "mod-sdk 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde-cw-value",
- "serde-json-wasm",
- "thiserror",
-]
-
-[[package]]
-name = "croncat-tasks"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2168feee489ecd54010c8856db1428eb0317d2749781f79569fd9f9ce00ba0ae"
-dependencies = [
- "cosmwasm-schema",
- "cosmwasm-std",
- "croncat-sdk-agents 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "croncat-sdk-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "croncat-sdk-factory 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "croncat-sdk-manager 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "croncat-sdk-tasks 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw-storage-plus 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "cw2 1.0.1",
- "cw20 0.16.0",
- "mod-sdk 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw20 1.0.1",
+ "cw20-base 1.0.1",
+ "mod-sdk",
  "serde-cw-value",
  "serde-json-wasm",
  "thiserror",
@@ -739,21 +562,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "451a4691083a88a3c0630a8a88799e9d4cd6679b7ce8ff22b8da2873ff31d380"
 dependencies = [
  "cosmwasm-std",
-]
-
-[[package]]
-name = "cw-boolean-contract"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c87f4bf89c22772585b5b808f91996afeb89b51cd374369928df068ba088718"
-dependencies = [
- "cosmwasm-schema",
- "cosmwasm-std",
- "cw-storage-plus 0.16.0",
- "cw2 0.16.0",
- "mod-sdk 0.1.5",
- "schemars",
- "thiserror",
 ]
 
 [[package]]
@@ -1104,6 +912,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "cw20"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91666da6c7b40c8dd5ff94df655a28114efc10c79b70b4d06f13c31e37d60609"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-utils 1.0.1",
+ "schemars",
+ "serde",
+]
+
+[[package]]
 name = "cw20-base"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1131,6 +952,24 @@ dependencies = [
  "cw-utils 0.16.0",
  "cw2 0.16.0",
  "cw20 0.16.0",
+ "schemars",
+ "semver",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "cw20-base"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afcd279230b08ed8afd8be5828221622bd5b9ce25d0b01d58bad626c6ce0169c"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-storage-plus 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw-utils 1.0.1",
+ "cw2 1.0.1",
+ "cw20 1.0.1",
  "schemars",
  "semver",
  "serde",
@@ -1258,6 +1097,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "cw721"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa49f5096cc1587489ac5d1d345936e8139738f40ad07a94c7b157b19f975c00"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-utils 1.0.1",
+ "schemars",
+ "serde",
+]
+
+[[package]]
 name = "cw721-base"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1269,6 +1121,25 @@ dependencies = [
  "cw-utils 0.16.0",
  "cw2 0.16.0",
  "cw721 0.16.0",
+ "schemars",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "cw721-base"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72c2be7476fa786c3adc96b00e33a0c5917d2a84774d94c5dd76e987c315570f"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-ownable",
+ "cw-storage-plus 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cw-utils 1.0.1",
+ "cw2 1.0.1",
+ "cw721 0.17.0",
+ "cw721-base 0.16.0",
  "schemars",
  "serde",
  "thiserror",
@@ -1778,29 +1649,7 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "mod-sdk"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce046f6337ae8c6497b6022dc7368566e4fb6e2d9dab1e164915785e4832c60b"
-dependencies = [
- "cosmwasm-schema",
- "cosmwasm-std",
- "thiserror",
-]
-
-[[package]]
-name = "mod-sdk"
 version = "1.0.0"
-dependencies = [
- "cosmwasm-schema",
- "cosmwasm-std",
- "thiserror",
-]
-
-[[package]]
-name = "mod-sdk"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1ae60ecabdb98d02ad1f1291cec14cdfa61cf00b6798a7eb5d9a2ac64c3e599"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ serde = { version = "1.0" }
 cosmwasm-std = { version = "1.1.9" }
 serde-cw-value = "0.7.0"
 thiserror = { version = "1.0" }
-cosmwasm-schema = { version = "=1.1.9" }
+cosmwasm-schema = { version = "1.1.9" }
 rusty-hook = "0.11.2"
 #For some reason it tries to deploy cw_core here
 # voting = { version = "0.2.0", default-features = false, git = "https://github.com/DA0-DA0/dao-contracts" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,24 +32,24 @@ license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]
 serde = { version = "1.0" }
-cosmwasm-std = { version = "1.1" }
+cosmwasm-std = { version = "1.2" }
 serde-cw-value = "0.7.0"
 thiserror = { version = "1.0" }
-cosmwasm-schema = { version = "1.1" }
+cosmwasm-schema = { version = "1.2" }
 rusty-hook = "0.11.2"
 #For some reason it tries to deploy cw_core here
 # voting = { version = "0.2.0", default-features = false, git = "https://github.com/DA0-DA0/dao-contracts" }
-cw20 = { version = "0.16.0" }
+cw20 = { version = "1.0.1" }
 cw-multi-test = { version = "0.16.0" }
-cw20-base = { version = "0.16.0" }
+cw20-base = { version = "1.0.1" }
 cw-storage-plus = "1.0.1"
 cron_schedule = "0.2.3"
 cw2 = "1.0.1"
 hex = { version = "0.4", default-features = false }
 sha2 = { version = "0.10.6", default-features = false }
 serde-json-wasm = { version = "0.5.0" }
-cw-utils = "0.16.0"
-cw721 = "0.16.0"
+cw-utils = "1.0.1"
+cw721 = "0.17.0"
 # DAO contracts
 dao-voting = { version = "2.0.0-beta", git = "https://github.com/DA0-DA0/dao-contracts.git" }
 dao-proposal-single = { version = "2.0.0-beta", git = "https://github.com/DA0-DA0/dao-contracts" }
@@ -64,7 +64,7 @@ cw4-group = "1.0.1"
 base64 = "0.13.0"
 serde_json = { version = "1.0" }
 anyhow = "1"
-cw721-base = "0.16.0"
+cw721-base = "0.17.0"
 croncat-agents = { path = "./contracts/croncat-agents" }
 croncat-manager = { path = "./contracts/croncat-manager" }
 croncat-tasks = { path = "./contracts/croncat-tasks" }
@@ -79,4 +79,4 @@ croncat-sdk-tasks = { path = "./packages/croncat-sdk-tasks" }
 mod-sdk = { path = "./packages/mod-sdk" }
 croncat-sdk-factory = { path = "./packages/croncat-sdk-factory" }
 croncat-sdk-manager = { path = "./packages/croncat-sdk-manager" }
-cw-boolean-contract = "0.1.3"
+# cw-boolean-contract = "0.1.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,10 +32,10 @@ license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]
 serde = { version = "1.0" }
-cosmwasm-std = { version = "1.1.9" }
+cosmwasm-std = { version = "1.1" }
 serde-cw-value = "0.7.0"
 thiserror = { version = "1.0" }
-cosmwasm-schema = { version = "1.1.9" }
+cosmwasm-schema = { version = "1.1" }
 rusty-hook = "0.11.2"
 #For some reason it tries to deploy cw_core here
 # voting = { version = "0.2.0", default-features = false, git = "https://github.com/DA0-DA0/dao-contracts" }

--- a/contracts/croncat-agents/Cargo.toml
+++ b/contracts/croncat-agents/Cargo.toml
@@ -30,11 +30,11 @@ library = []
 [dependencies]
 cosmwasm-std = { workspace = true }
 cosmwasm-schema = { workspace = true }
-croncat-sdk-agents = { version = "1.0.0" }
-croncat-sdk-tasks = { version = "1.0.0" }
-croncat-sdk-core = { version = "1.0.0" }
-croncat-sdk-manager = { version = "1.0.0" }
-croncat-sdk-factory = { version = "1.0.0" }
+croncat-sdk-agents = { workspace = true }
+croncat-sdk-tasks = { workspace = true }
+croncat-sdk-core = { workspace = true }
+croncat-sdk-manager = { workspace = true }
+croncat-sdk-factory = { workspace = true }
 cw-storage-plus = { workspace = true }
 thiserror = { workspace = true }
 serde = { workspace = true, default-features = false, features = ["derive"] }
@@ -44,8 +44,8 @@ cw-utils = { workspace = true }
 [dev-dependencies]
 cw-multi-test = { workspace = true }
 anyhow = { workspace = true }
-croncat-manager = { version = "1.0.0" }
-croncat-tasks = { version = "1.0.0" }
-croncat-factory = { version = "1.0.0" }
+croncat-manager = { workspace = true }
+croncat-tasks = { workspace = true }
+croncat-factory = { workspace = true }
 croncat-agents = { workspace = true }
-croncat-sdk-factory = { version = "1.0.0" }
+croncat-sdk-factory = { workspace = true }

--- a/contracts/croncat-factory/Cargo.toml
+++ b/contracts/croncat-factory/Cargo.toml
@@ -34,18 +34,18 @@ thiserror = { workspace = true }
 cw2 = { workspace = true }
 cw-storage-plus = { workspace = true }
 cw-utils = { workspace = true }
-croncat-sdk-core = { version = "1.0.0" }
-croncat-sdk-factory = { version = "1.0.0" }
+croncat-sdk-core = { workspace = true }
+croncat-sdk-factory = { workspace = true }
 
 [dev-dependencies]
 cw-multi-test = { workspace = true }
-croncat-tasks = { version = "1.0.0" }
-croncat-manager = { version = "1.0.0" }
-croncat-agents = { version = "1.0.0" }
-croncat-mod-balances = { version = "1.0.0" }
-croncat-sdk-core = { version = "1.0.0" }
-croncat-sdk-factory = { version = "1.0.0" }
-croncat-sdk-manager = { version = "1.0.0" }
+croncat-tasks = { workspace = true }
+croncat-manager = { workspace = true }
+croncat-agents = { workspace = true }
+croncat-mod-balances = { workspace = true }
+croncat-sdk-core = { workspace = true }
+croncat-sdk-factory = { workspace = true }
+croncat-sdk-manager = { workspace = true }
 anyhow = { workspace = true }
 cw20-base = { workspace = true }
 cw20 = { workspace = true }

--- a/contracts/croncat-manager/Cargo.toml
+++ b/contracts/croncat-manager/Cargo.toml
@@ -30,29 +30,29 @@ library = []
 [dependencies]
 cosmwasm-std = { workspace = true, features = ["staking"] }
 cosmwasm-schema = { workspace = true }
-croncat-sdk-manager = { version = "1.0.0" }
-croncat-sdk-agents = { version = "1.0.0" }
-croncat-sdk-tasks = { version = "1.0.0" }
-croncat-sdk-core = { version = "1.0.0" }
+croncat-sdk-manager = { workspace = true }
+croncat-sdk-agents = { workspace = true }
+croncat-sdk-tasks = { workspace = true }
+croncat-sdk-core = { workspace = true }
 cw-utils = { workspace = true }
-croncat-sdk-factory = { version = "1.0.0" }
+croncat-sdk-factory = { workspace = true }
 cw-storage-plus = { workspace = true }
 cw2 = { workspace = true }
 cw20 = { workspace = true }
 thiserror = { workspace = true }
-mod-sdk = { version = "1.0.0" }
+mod-sdk = { workspace = true }
 serde-json-wasm = { workspace = true }
 serde-cw-value = { workspace = true }
 
 [dev-dependencies]
 cw-multi-test = { workspace = true }
 cw20-base = { workspace = true }
-croncat-factory = { version = "1.0.0" }
-croncat-sdk-factory = { version = "1.0.0" }
-croncat-sdk-manager = { version = "1.0.0" }
-croncat-tasks = { version = "1.0.0" }
-croncat-agents = { version = "1.0.0" }
-croncat-mod-balances = { version = "1.0.0" }
-croncat-mod-generic = { version = "1.0.0" }
-cw-boolean-contract = { workspace = true }
+croncat-factory = { workspace = true }
+croncat-sdk-factory = { workspace = true }
+croncat-sdk-manager = { workspace = true }
+croncat-tasks = { workspace = true }
+croncat-agents = { workspace = true }
+croncat-mod-balances = { workspace = true }
+croncat-mod-generic = { workspace = true }
+# cw-boolean-contract = { workspace = true }
 serde_json = { workspace = true }

--- a/contracts/croncat-tasks/Cargo.toml
+++ b/contracts/croncat-tasks/Cargo.toml
@@ -37,22 +37,22 @@ cw-storage-plus = { workspace = true }
 cw20 = { workspace = true }
 cw2 = { workspace = true }
 
-croncat-sdk-tasks = { version = "1.0.0" }
-croncat-sdk-factory = { version = "1.0.0" }
-croncat-sdk-core = { version = "1.0.0" }
-croncat-sdk-manager = { version = "1.0.0" }
-croncat-sdk-agents = { version = "1.0.0" }
-mod-sdk = { version = "1.0.0" }
+croncat-sdk-tasks = { workspace = true }
+croncat-sdk-factory = { workspace = true }
+croncat-sdk-core = { workspace = true }
+croncat-sdk-manager = { workspace = true }
+croncat-sdk-agents = { workspace = true }
+mod-sdk = { workspace = true }
 
 [dev-dependencies]
 cw-multi-test = { workspace = true }
-croncat-factory = { version = "1.0.0" }
-croncat-manager = { version = "1.0.0" }
-croncat-agents = { version = "1.0.0" }
-croncat-sdk-factory = { version = "1.0.0" }
-croncat-sdk-manager = { version = "1.0.0" }
-croncat-mod-balances = { version = "1.0.0" }
-croncat-mod-generic = { version = "1.0.0" }
+croncat-factory = { workspace = true }
+croncat-manager = { workspace = true }
+croncat-agents = { workspace = true }
+croncat-sdk-factory = { workspace = true }
+croncat-sdk-manager = { workspace = true }
+croncat-mod-balances = { workspace = true }
+croncat-mod-generic = { workspace = true }
 anyhow = { workspace = true }
 cw-utils = { workspace = true }
 cw20-base = { workspace = true }

--- a/contracts/mod-balances/Cargo.toml
+++ b/contracts/mod-balances/Cargo.toml
@@ -32,7 +32,7 @@ cosmwasm-std = { workspace = true }
 cosmwasm-schema = { workspace = true }
 cw2 = { workspace = true }
 cw20 = { workspace = true }
-mod-sdk = { version = "1.0.0" }
+mod-sdk = { workspace = true }
 
 [dev-dependencies]
 cw20-base = { workspace = true }

--- a/contracts/mod-dao/Cargo.toml
+++ b/contracts/mod-dao/Cargo.toml
@@ -31,7 +31,7 @@ library = []
 cosmwasm-std = { workspace = true }
 cosmwasm-schema = { workspace = true }
 cw2 = { workspace = true }
-mod-sdk = { version = "1.0.0" }
+mod-sdk = { workspace = true }
 schemars = "0.8.11"
 serde = { workspace = true }
 dao-proposal-single = { workspace = true, features = ["library"] }

--- a/contracts/mod-generic/Cargo.toml
+++ b/contracts/mod-generic/Cargo.toml
@@ -31,7 +31,7 @@ library = []
 cosmwasm-std = { workspace = true }
 cosmwasm-schema = { workspace = true }
 cw2 = { workspace = true }
-mod-sdk = { version = "1.0.0" }
+mod-sdk = { workspace = true }
 serde-cw-value = { workspace = true }
 serde-json-wasm = { workspace = true }
 
@@ -42,5 +42,5 @@ cw4-group = { workspace = true }
 cw20 = { workspace = true }
 cw20-base = { workspace = true }
 cw-multi-test = { workspace = true }
-croncat-mod-balances = { version = "1.0.0" }
+croncat-mod-balances = { workspace = true }
 cw-utils = { workspace = true }

--- a/contracts/mod-nft/Cargo.toml
+++ b/contracts/mod-nft/Cargo.toml
@@ -32,7 +32,7 @@ cosmwasm-std = { workspace = true }
 cosmwasm-schema = { workspace = true }
 cw2 = { workspace = true }
 cw721 = { workspace = true }
-mod-sdk = { version = "1.0.0" }
+mod-sdk = { workspace = true }
 
 [dev-dependencies]
 cw721-base = { workspace = true }

--- a/integration-sdk/croncat-integration-testing/Cargo.toml
+++ b/integration-sdk/croncat-integration-testing/Cargo.toml
@@ -12,18 +12,18 @@ thiserror = { workspace = true }
 cosmwasm-schema = { workspace = true }
 cosmwasm-std = { workspace = true }
 cw20 = { workspace = true }
-croncat-sdk-agents = { version = "1.0.0" }
-croncat-sdk-factory = { version = "1.0.0" }
-croncat-sdk-tasks = { version = "1.0.0" }
-croncat-sdk-manager = { version = "1.0.0" }
+croncat-sdk-agents = { workspace = true }
+croncat-sdk-factory = { workspace = true }
+croncat-sdk-tasks = { workspace = true }
+croncat-sdk-manager = { workspace = true }
 cw-utils = { workspace = true }
 serde-json-wasm = { workspace = true }
 serde_json = { workspace = true }
 # These are for the src/tests/contracts.rs file
-croncat-agents = { version = "1.0.0" }
-croncat-tasks = { version = "1.0.0" }
-croncat-manager = { version = "1.0.0" }
-croncat-factory = { version = "1.0.0" }
+croncat-agents = { workspace = true }
+croncat-tasks = { workspace = true }
+croncat-manager = { workspace = true }
+croncat-factory = { workspace = true }
 cw-multi-test = { workspace = true }
 
 [dev-dependencies]

--- a/integration-sdk/croncat-integration-utils/Cargo.toml
+++ b/integration-sdk/croncat-integration-utils/Cargo.toml
@@ -12,11 +12,11 @@ thiserror = { workspace = true }
 cosmwasm-schema = { workspace = true }
 cosmwasm-std = { workspace = true }
 cw20 = { workspace = true }
-croncat-sdk-agents = { version = "1.0.0" }
-croncat-sdk-factory = { version = "1.0.0" }
-croncat-sdk-tasks = { version = "1.0.0" }
-croncat-sdk-manager = { version = "1.0.0" }
-croncat-mod-generic = { version = "1.0.0" }
+croncat-sdk-agents = { workspace = true }
+croncat-sdk-factory = { workspace = true }
+croncat-sdk-tasks = { workspace = true }
+croncat-sdk-manager = { workspace = true }
+croncat-mod-generic = { workspace = true }
 cw-utils = { workspace = true }
 serde-json-wasm = { workspace = true }
 serde_json = { workspace = true }

--- a/packages/croncat-sdk-agents/Cargo.toml
+++ b/packages/croncat-sdk-agents/Cargo.toml
@@ -12,4 +12,4 @@ cosmwasm-std = { workspace = true }
 cosmwasm-schema = { workspace = true }
 serde = { workspace = true, default-features = false, features = ["derive"] }
 thiserror = { workspace = true }
-croncat-sdk-core = { version = "1.0.0" }
+croncat-sdk-core = { workspace = true }

--- a/packages/croncat-sdk-manager/Cargo.toml
+++ b/packages/croncat-sdk-manager/Cargo.toml
@@ -13,5 +13,5 @@ cosmwasm-schema = { workspace = true }
 thiserror = { workspace = true }
 cw20 = { workspace = true }
 cw-storage-plus = { workspace = true}
-croncat-sdk-core = { version = "1.0.0" }
-croncat-sdk-tasks = { version = "1.0.0" }
+croncat-sdk-core = { workspace = true }
+croncat-sdk-tasks = { workspace = true }

--- a/packages/croncat-sdk-tasks/Cargo.toml
+++ b/packages/croncat-sdk-tasks/Cargo.toml
@@ -13,9 +13,9 @@ cosmwasm-schema = { workspace = true }
 cw20 = { workspace = true }
 cron_schedule = { workspace = true }
 
-croncat-mod-generic = { version = "1.0.0", features = ["library"]}
-croncat-sdk-core = { version = "1.0.0" }
-mod-sdk = { version = "1.0.0" }
+croncat-mod-generic = { workspace = true, features = ["library"]}
+croncat-sdk-core = { workspace = true }
+mod-sdk = { workspace = true }
 
 sha2 = { workspace = true }
 hex = { workspace = true }


### PR DESCRIPTION
## Reason for change
I'm working on a Croncat integration and was stuck on a versioning issue related to `cosmwasm_schema`. 
I think it was because of the strict requirement on `cosmwasm_schema` but i'm not sure. 

## What I did
I removed that requirement and bumped the cosmwasm versions to 1.2 because that's what everyone is rocking now. 
I commented out the `cw-boolean-contract` import in the manager crate and changed the imports to use the local path to get things to compile. A PR on the boolean contract will have to be done in order to merge this.

I can keep using my fork for development if you want to stick to your current versions. 